### PR TITLE
[Fix] View의 배경색을 설정하여 화면 전환시 잔상이 남는 이슈 해결

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/View/EditFolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/View/EditFolderView.swift
@@ -18,8 +18,13 @@ final class EditFolderView: UIView {
 
 private extension EditFolderView {
     func configure() {
+        setAttributes()
         setHierarchy()
         setConstraints()
+    }
+
+    func setAttributes() {
+        backgroundColor = .systemBackground
     }
 
     func setHierarchy() {


### PR DESCRIPTION
## 📌 관련 이슈

close #42 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

화면 전환 시 이전 화면이 잔상처럼 남아있는 이슈 해결

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/f274dd0d-158c-4cf9-ad71-c49cce984bad" width="250px"> |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/dcfb0618-f0f3-472f-8a31-94d5fb734441" width="250px"> |