### PR TITLE
[Feat] FolderView 삭제 기능 구현

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
@@ -141,9 +141,24 @@ private extension FolderViewController {
 
         folderView.didTapDeleteButton
             .asDriver(onErrorDriveWith: .empty())
-            .drive { [weak self] indexPath in
+            .drive { [weak self] (indexPath, title) in
                 guard let self else { return }
-                viewModel.action.accept(.didTapDeleteButton(indexPath))
+
+                let alertController = UIAlertController(
+                    title: title,
+                    message: "삭제하겠습니까?",
+                    preferredStyle: .alert,
+                )
+
+                let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+                alertController.addAction(cancelAction)
+
+                let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { _ in
+                    self.viewModel.action.accept(.didTapDeleteButton(indexPath))
+                }
+                alertController.addAction(deleteAction)
+
+                self.present(alertController, animated: true)
             }
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 📌 관련 이슈

close #146
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- CollectionView를 TableView로 마이그레이션
- Trailing Swipe 삭제 구현
- 삭제 확인 Alert 구현

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/b11ace56-b6f9-4f3d-a6d3-6e44b720d7a6" width="250px"> |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/ee84af32-1414-49ee-9615-8ee7d6128a6c" width="250px"> |

## 📌 참고 사항

UI 수정은 미포함입니다.
