### PR TITLE
FolderCell 탭 이벤트 바인딩

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -7,7 +7,8 @@ final class HomeView: UIView {
     enum Action {
         case tapAddFolder
         case tapAddClip
-        case tapCell(IndexPath)
+        case tapClip(Int)
+        case tapFolder(Int)
         case detail(IndexPath)
         case edit(IndexPath)
         case delete(IndexPath)
@@ -64,7 +65,6 @@ final class HomeView: UIView {
         let tableView = UITableView()
         tableView.backgroundColor = #colorLiteral(red: 0.9813517928, green: 0.9819430709, blue: 1, alpha: 1)
         tableView.separatorStyle = .none
-        tableView.allowsSelection = false
         tableView.rowHeight = 72
         tableView.register(FolderCell.self, forCellReuseIdentifier: FolderCell.identifier)
         tableView.isScrollEnabled = false
@@ -370,7 +370,12 @@ private extension HomeView {
 
     func setBindings() {
         collectionView.rx.itemSelected
-            .map { Action.tapCell($0) }
+            .map { Action.tapClip($0.item) }
+            .bind(to: action)
+            .disposed(by: disposeBag)
+
+        tableView.rx.itemSelected
+            .map { Action.tapFolder($0.row) }
             .bind(to: action)
             .disposed(by: disposeBag)
     }

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -53,8 +53,10 @@ private extension HomeViewController {
                     owner.homeviewModel.action.accept(.tapAddFolder)
                 case .tapAddClip:
                     owner.homeviewModel.action.accept(.tapAddClip)
-                case .tapCell(let indexPath):
-                    owner.homeviewModel.action.accept(.tapCell(indexPath))
+                case .tapClip(let index):
+                    owner.homeviewModel.action.accept(.tapClip(index))
+                case .tapFolder(let index):
+                    owner.homeviewModel.action.accept(.tapFolder(index))
                 case .detail(let indexPath):
                     owner.homeviewModel.action.accept(.tapDetail(indexPath))
                 case .edit(let indexPath):

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
@@ -7,7 +7,8 @@ final class HomeViewModel {
         case viewWillAppear
         case tapAddClip
         case tapAddFolder
-        case tapCell(IndexPath)
+        case tapClip(Int)
+        case tapFolder(Int)
         case tapDetail(IndexPath)
         case tapEdit(IndexPath)
         case tapDelete(IndexPath)
@@ -66,8 +67,15 @@ final class HomeViewModel {
                     owner.route.accept(.showAddClip)
                 case .tapAddFolder:
                     owner.route.accept(.showAddFolder)
-                case .tapCell(let indexPath),
-                     .tapDetail(let indexPath),
+                case .tapClip(let index):
+                    guard index < owner.unvisitedClips.count else { return }
+                    let url = owner.unvisitedClips[index].urlMetadata.url
+                    owner.route.accept(.showWebView(url))
+                case .tapFolder(let index):
+                    guard index < owner.folders.count else { return }
+                    let folder = owner.folders[index]
+                    owner.route.accept(.showFolder(folder))
+                case .tapDetail(let indexPath),
                      .tapEdit(let indexPath):
                     if let route = owner.route(for: action, at: indexPath) {
                         owner.route.accept(route)
@@ -86,8 +94,6 @@ final class HomeViewModel {
         case 0 where indexPath.item < unvisitedClips.count:
             let clip = unvisitedClips[indexPath.item]
             switch action {
-            case .tapCell:
-                return .showWebView(clip.urlMetadata.url)
             case .tapDetail:
                 return .showDetailClip(clip)
             case .tapEdit:
@@ -98,8 +104,6 @@ final class HomeViewModel {
         case 1 where indexPath.item < folders.count:
             let folder = folders[indexPath.item]
             switch action {
-            case .tapCell:
-                return .showFolder(folder)
             case .tapEdit:
                 return .showEditFolder(folder)
             default:


### PR DESCRIPTION
## 📌 관련 이슈
close #183 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- FolderCell 탭 이벤트 바인딩

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/14356543-9ef3-4bad-9df6-589ad8027c3c" width="250px"> |

## 📌 PR Point
- 화면이동 시 잔상이 보이는 현상이 발생 이 부분은 추후에 수정