### PR TITLE
메모 글자수 제한 피그마와 동일하게 표현

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -156,7 +156,7 @@ private extension EditClipViewController {
         viewModel.state
             .map(\.memoLimit)
             .distinctUntilChanged()
-            .asDriver(onErrorJustReturn: "0/100")
+            .asDriver(onErrorJustReturn: "0 / 100")
             .drive(editClipView.memoView.memoLimitLabel.rx.text)
             .disposed(by: disposeBag)
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -38,7 +38,7 @@ final class EditClipViewModel: ViewModel {
         var isHiddenURLMetadataStackView = true
         var isHiddenURLValidationStackView = true
         var memoText: String = ""
-        var memoLimit: String = "0/100"
+        var memoLimit: String = "0 / 100"
         var isURLValid = false
         var urlValidationImageName: String = ""
         var urlValidationLabelText: String = ""
@@ -100,7 +100,7 @@ final class EditClipViewModel: ViewModel {
             type: .edit,
             urlInputText: clip.urlMetadata.url.absoluteString,
             memoText: clip.memo,
-            memoLimit: "\(clip.memo.count)/100",
+            memoLimit: "\(clip.memo.count) / 100",
             clip: clip,
             navigationTitle: "클립 수정"
         ))
@@ -235,7 +235,7 @@ final class EditClipViewModel: ViewModel {
             }
         case .updateMemo(let memoText):
             newState.memoText = memoText
-            newState.memoLimit = "\(memoText.count)/100"
+            newState.memoLimit = "\(memoText.count) / 100"
         case .updateValidURL(let result):
             newState.isURLValid = result
             newState.urlValidationImageName = result ? "CheckBlue" : "XRed"


### PR DESCRIPTION
## 📌 관련 이슈

close #258 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 메모 글자수 제한 표현 방식 변경

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/baaed963-93d2-4171-823b-f59b93c8137c" width="250px"> |
