### PR TITLE
썸네일이 없어도 오류로 처리하지 않도록 수정

### DIFF
--- a/Clipster/Clipster/Data/Util/Mapper/DomainMapper.swift
+++ b/Clipster/Clipster/Data/Util/Mapper/DomainMapper.swift
@@ -40,15 +40,12 @@ struct DomainMapper {
     }
 
     private func urlMetadata(from entity: URLMetadataEntity) -> URLMetadata? {
-        guard let url = URL(string: entity.urlString),
-              let thumbnailImageURL = URL(string: entity.thumbnailImageURLString ?? "") else {
-            return nil
-        }
+        guard let url = URL(string: entity.urlString) else { return nil }
 
         return URLMetadata(
             url: url,
             title: entity.title,
-            thumbnailImageURL: thumbnailImageURL,
+            thumbnailImageURL: URL(string: entity.thumbnailImageURLString ?? ""),
             createdAt: entity.createdAt,
             updatedAt: entity.updatedAt,
             deletedAt: entity.deletedAt,


### PR DESCRIPTION
## 📌 관련 이슈

close #264 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

ThumbnailImageURL이 nil값이 허용되도록 기획이 수정되었는데, DomainMapper에서는 이를 허용하지 않아서 클립이 추가되지 않은 것처럼 보이는 이슈가 있었습니다. nil이여도 URLMetadata를 init하는데 실패하지 않도록 수정했습니다.

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/c8ae9de6-dfa2-4d13-a1b2-3988ec9ae311

## 📌 참고 사항

일단 추가는 되는데, 셀 표시가 정상적으로 되지는 않습니다. 이슈로 추가하겠습니다.
