### PR TITLE
ClipListCell 썸네일 이미지 없을경우 셀 높이 낮아지는 현상 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/Cell/ClipListCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Cell/ClipListCell.swift
@@ -99,15 +99,16 @@ private extension ClipListCell {
 
     func setConstraints() {
         thumbnailImageView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(12)
             make.leading.equalToSuperview().inset(44)
+            make.bottom.equalToSuperview().inset(12).priority(.high)
             make.width.equalTo(64)
             make.height.equalTo(48)
-            make.centerY.equalToSuperview()
         }
 
         stackView.snp.makeConstraints { make in
             make.leading.equalTo(thumbnailImageView.snp.trailing).offset(16)
-            make.verticalEdges.equalToSuperview().inset(12.95)
+            make.centerY.equalToSuperview()
         }
 
         chevronImageView.snp.makeConstraints { make in


### PR DESCRIPTION
## 📌 관련 이슈

close #327 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- FolderListCell과 마찬가지로 아래코드를 통해 해결
`make.bottom.equalToSuperview().inset(12).priority(.high)`
## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/5616bc10-d2ef-47df-b580-fdd858a7ab75" width="250px"> |