### PR TITLE
홈, 방문하지 않은 클립 화면 push 한번만 일어나도록 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -80,7 +80,8 @@ private extension HomeViewController {
             .disposed(by: disposeBag)
 
         homeviewModel.route
-            .asSignal()
+            .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
+            .asSignal(onErrorSignalWith: .empty())
             .emit(with: self) { owner, route in
                 switch route {
                 case .showAddClip(let folder):

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
@@ -77,7 +77,8 @@ private extension UnvisitedClipListViewController {
             .disposed(by: disposeBag)
 
         unvisitedClipListViewModel.route
-            .asSignal()
+            .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
+            .asSignal(onErrorSignalWith: .empty())
             .emit(with: self) { owner, route in
                 switch route {
                 case .back:


### PR DESCRIPTION
## 📌 관련 이슈
- close #330 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 화면 이동시 throttle처리를 통한 중복 push 방지