### PR TITLE
FolderView Navigation에 throttle 적용

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
@@ -54,6 +54,7 @@ private extension FolderViewController {
             .disposed(by: disposeBag)
 
         viewModel.navigation
+            .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] navigation in
                 guard let self else { return }


### PR DESCRIPTION
## 📌 관련 이슈

close #331
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

FolderView Navigation에 throttle을 적용하여 중복 이벤트가 발생하지 않도록 처리했습니다.

## 📌 참고 사항

기존 이슈가 있었을 때도, 제 시뮬레이터와 디바이스에서는 재연이 안돼서 스크린샷이나 영상은 첨부하지 못했습니다.
