### PR TITLE
ClipCell에서 제목이나 메모가 비어있는 경우에도 자리를 차지하도록 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Util/Mapper/ClipDisplayMapper.swift
+++ b/Clipster/Clipster/Presentation/Util/Mapper/ClipDisplayMapper.swift
@@ -4,14 +4,14 @@ struct ClipDisplayMapper {
     static func map(_ clip: Clip) -> ClipDisplay {
         let urlMetadataDisplay = URLMetadataDisplay(
             url: clip.urlMetadata.url,
-            title: clip.urlMetadata.title,
+            title: clip.urlMetadata.title.isEmpty ? " " : clip.urlMetadata.title,
             thumbnailImageURL: clip.urlMetadata.thumbnailImageURL
         )
 
         return ClipDisplay(
             id: clip.id,
             urlMetadata: urlMetadataDisplay,
-            memo: clip.memo,
+            memo: clip.memo.isEmpty ? " " : clip.memo,
             memoLimit: "\(clip.memo.count) / 100",
             isVisited: clip.lastVisitedAt != nil
         )


### PR DESCRIPTION
## 📌 관련 이슈

close #338
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

ClipCell에서 제목이나 메모가 비어있는 경우에도 자리를 차지하도록 수정(제목이 비어있는 경우는 당장은 없을테지만, 그래도 넣었습니다.)

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/d545238b-3cbb-4319-ac63-8178ef5dc3df" width="250px"> |
