### PR TITLE
홈화면 섹션별 높이 같도록 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -256,7 +256,7 @@ private extension HomeView {
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
         section.interGroupSpacing = 16
-        section.contentInsets = .init(top: 8, leading: 24, bottom: 24, trailing: 24)
+        section.contentInsets = .init(top: 8, leading: 24, bottom: 40, trailing: 24)
         section.boundarySupplementaryItems = [makeHeaderItemLayout(for: .clip)]
 
         return section
@@ -284,27 +284,15 @@ private extension HomeView {
         }
             let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: env)
             section.boundarySupplementaryItems = [makeHeaderItemLayout(for: .folder)]
-            section.contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 24)
+            section.contentInsets = .init(top: 8, leading: 0, bottom: 24, trailing: 24)
             section.interGroupSpacing = 8
             return section
         }
 
         func makeHeaderItemLayout(for section: Section) -> NSCollectionLayoutBoundarySupplementaryItem {
-            let heightDimension: NSCollectionLayoutDimension
-            var contentInsets: NSDirectionalEdgeInsets
-
-            switch section {
-            case .clip:
-                heightDimension = .absolute(48)
-                contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
-            case .folder:
-                heightDimension = .absolute(56)
-                contentInsets = .init(top: 0, leading: 24, bottom: 8, trailing: 24)
-            }
-
             let headerSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: heightDimension
+                heightDimension: .absolute(48)
             )
 
             let header = NSCollectionLayoutBoundarySupplementaryItem(
@@ -312,7 +300,14 @@ private extension HomeView {
                 elementKind: UICollectionView.elementKindSectionHeader,
                 alignment: .top
             )
-            header.contentInsets = contentInsets
+
+            switch section {
+            case .clip:
+                header.contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
+            case .folder:
+                header.contentInsets = .init(top: 0, leading: 24, bottom: 0, trailing: 24)
+            }
+
             return header
         }
     }

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -290,9 +290,21 @@ private extension HomeView {
         }
 
         func makeHeaderItemLayout(for section: Section) -> NSCollectionLayoutBoundarySupplementaryItem {
+            let heightDimension: NSCollectionLayoutDimension
+            var contentInsets: NSDirectionalEdgeInsets
+
+            switch section {
+            case .clip:
+                heightDimension = .absolute(48)
+                contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
+            case .folder:
+                heightDimension = .absolute(56)
+                contentInsets = .init(top: 0, leading: 24, bottom: 8, trailing: 24)
+            }
+
             let headerSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(48)
+                heightDimension: heightDimension
             )
 
             let header = NSCollectionLayoutBoundarySupplementaryItem(
@@ -300,14 +312,7 @@ private extension HomeView {
                 elementKind: UICollectionView.elementKindSectionHeader,
                 alignment: .top
             )
-
-            switch section {
-            case .clip:
-                header.contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
-            case .folder:
-                header.contentInsets = .init(top: 0, leading: 24, bottom: 8, trailing: 24)
-            }
-
+            header.contentInsets = contentInsets
             return header
         }
     }

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -256,7 +256,7 @@ private extension HomeView {
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
         section.interGroupSpacing = 16
-        section.contentInsets = .init(top: 16, leading: 24, bottom: 24, trailing: 24)
+        section.contentInsets = .init(top: 8, leading: 24, bottom: 24, trailing: 24)
         section.boundarySupplementaryItems = [makeHeaderItemLayout(for: .clip)]
 
         return section


### PR DESCRIPTION
## 📌 관련 이슈
close #379 
close #391 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
섹션 별 높이 48로 고정 및 8 여백 동일하게 수정

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/264c21b3-6088-4736-9ef4-725d73de67c3" width="500px"> |
