### PR TITLE
폴더뷰 EmptyAddButton 추가 및 바인딩

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
@@ -63,6 +63,16 @@ final class FolderView: UIView {
 
     private let emptyView = EmptyView(type: .folderView)
 
+    private let emptyAddButton: UIButton = {
+        let button = UIButton()
+        button.setImage(.addButtonBlue, for: .normal)
+        button.setImage(.addButtonBlue, for: .highlighted)
+        button.imageView?.contentMode = .scaleAspectFit
+        button.backgroundColor = .clear
+        button.isHidden = true
+        return button
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
@@ -94,8 +104,9 @@ final class FolderView: UIView {
         dataSource?.apply(snapshot, animatingDifferences: false)
     }
 
-    func setDisplay(isEmptyViewHidden: Bool) {
-        emptyView.isHidden = isEmptyViewHidden
+    func setDisplay(isHidden: Bool) {
+        emptyView.isHidden = isHidden
+        emptyAddButton.isHidden = isHidden
     }
 }
 
@@ -278,7 +289,7 @@ private extension FolderView {
     }
 
     func setHierarchy() {
-        [navigationView, collectionView, emptyView].forEach {
+        [navigationView, collectionView, emptyView, emptyAddButton].forEach {
             addSubview($0)
         }
     }
@@ -304,7 +315,16 @@ private extension FolderView {
         }
 
         emptyView.snp.makeConstraints { make in
-            make.center.equalToSuperview()
+            make.top.equalToSuperview().inset(291)
+            make.height.equalTo(146)
+            make.centerX.equalToSuperview()
+        }
+
+        emptyAddButton.snp.makeConstraints { make in
+            make.top.equalTo(emptyView.snp.bottom).offset(32)
+            make.width.equalTo(160)
+            make.height.equalTo(48)
+            make.centerX.equalToSuperview()
         }
     }
 
@@ -373,6 +393,11 @@ private extension FolderView {
                 guard let self else { return }
                 action.accept(.didTapCell(indexPath))
             }
+            .disposed(by: disposeBag)
+
+        emptyAddButton.rx.tap
+            .map { Action.didTapAddClipButton }
+            .bind(to: action)
             .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
@@ -95,7 +95,7 @@ private extension FolderViewController {
             .distinctUntilChanged()
             .bind { [weak self] isHidden in
                 guard let self else { return }
-                folderView.setDisplay(isEmptyViewHidden: isHidden)
+                folderView.setDisplay(isHidden: isHidden)
             }
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 📌 관련 이슈
close #373 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- EmptyAddButton 추가 및 바인딩

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/351c4c00-fe21-4378-acf9-afdf566c25ea" width="250px"> |