### PR TITLE
SF Symbol 이미지 대신 Asset 이미지로 변경

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/Button/BackButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Button/BackButton.swift
@@ -29,7 +29,8 @@ private extension BackButton {
         let pointSize: CGFloat = hasTitle ? 12 : 16
 
         let symbolConfig = UIImage.SymbolConfiguration(pointSize: pointSize, weight: .medium)
-        let image = UIImage(systemName: "chevron.left", withConfiguration: symbolConfig)?
+        let image = UIImage.chevronLeft
+            .withConfiguration(symbolConfig)
             .withTintColor(.black100, renderingMode: .alwaysOriginal)
 
         var config = UIButton.Configuration.plain()

--- a/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
@@ -188,14 +188,18 @@ extension FolderView: UICollectionViewDelegate {
 
 private extension FolderView {
     func makeAddButtonMenu() -> UIMenu {
-        let addFolderAction = UIAction(title: "폴더 추가", image: .folderPlus) { [weak self] _ in
-            guard let self else { return }
-            action.accept(.didTapAddFolderButton)
+        let addFolderAction = UIAction(
+            title: "폴더 추가",
+            image: .folderPlus
+        ) { [weak self] _ in
+            self?.action.accept(.didTapAddFolderButton)
         }
 
-        let addClipAction = UIAction(title: "클립 추가", image: .clip) { [weak self] _ in
-            guard let self else { return }
-            action.accept(.didTapAddClipButton)
+        let addClipAction = UIAction(
+            title: "클립 추가",
+            image: .clip
+        ) { [weak self] _ in
+            self?.action.accept(.didTapAddClipButton)
         }
 
         return UIMenu(title: "", children: [addFolderAction, addClipAction])
@@ -204,7 +208,7 @@ private extension FolderView {
     func makeDetailAction(for indexPath: IndexPath) -> UIAction {
         .init(
             title: "상세정보",
-            image: UIImage(systemName: "magnifyingglass")
+            image: .info
         ) { [weak self] _ in
             self?.performAction(for: indexPath) { .didTapDetailButton($0) }
         }
@@ -213,7 +217,7 @@ private extension FolderView {
     func makeEditAction(for indexPath: IndexPath) -> UIAction {
         .init(
             title: "편집",
-            image: UIImage(systemName: "pencil")
+            image: .pen
         ) { [weak self] _ in
             self?.performAction(for: indexPath) { .didTapEditButton($0) }
         }
@@ -222,7 +226,7 @@ private extension FolderView {
     func makeDeleteAction(for indexPath: IndexPath) -> UIAction {
         .init(
             title: "삭제",
-            image: UIImage(systemName: "trash"),
+            image: .trashRed,
             attributes: .destructive
         ) { [weak self] _ in
             self?.performAction(for: indexPath) {

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -172,14 +172,14 @@ final class HomeView: UIView {
     private func makeAddButtonMenu() -> UIMenu {
         let addFolderAction = UIAction(
             title: "폴더 추가",
-            image: UIImage(systemName: "folder")
+            image: .folderPlus
         ) { [weak self] _ in
             self?.action.accept(.tapAddFolder)
         }
 
         let addClipAction = UIAction(
             title: "클립 추가",
-            image: UIImage(systemName: "paperclip"),
+            image: .clip,
         ) { [weak self] _ in
             self?.action.accept(.tapAddClip)
         }
@@ -346,7 +346,7 @@ private extension HomeView {
     private func makeDetailAction(for indexPath: IndexPath) -> UIAction {
         .init(
             title: "상세정보",
-            image: UIImage(systemName: "magnifyingglass")
+            image: .info
         ) { [weak self] _ in
             self?.performAction(for: indexPath) { .detail($0) }
         }
@@ -355,7 +355,7 @@ private extension HomeView {
     func makeEditAction(for indexPath: IndexPath) -> UIAction {
         .init(
             title: "편집",
-            image: UIImage(systemName: "pencil")
+            image: .pen
         ) { [weak self] _ in
             self?.performAction(for: indexPath) { .edit($0) }
         }
@@ -364,7 +364,7 @@ private extension HomeView {
     func makeDeleteAction(for indexPath: IndexPath) -> UIAction {
         .init(
             title: "삭제",
-            image: UIImage(systemName: "trash"),
+            image: .trashRed,
             attributes: .destructive
         ) { [weak self] _ in
             self?.performAction(for: indexPath) { .delete(indexPath: $0, title: $1.displayTitle) }

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
@@ -132,21 +132,21 @@ extension UnvisitedClipListView: UICollectionViewDelegate {
 
             let info = UIAction(
                 title: "상세정보",
-                image: UIImage(systemName: "magnifyingglass")
+                image: .info
             ) { [weak self] _ in
                 self?.action.accept(.detail(indexPath.item))
             }
 
             let edit = UIAction(
                 title: "편집",
-                image: UIImage(systemName: "pencil")
+                image: .pen
             ) { [weak self] _ in
                 self?.action.accept(.edit(indexPath.item))
             }
 
             let delete = UIAction(
                 title: "삭제",
-                image: UIImage(systemName: "trash"),
+                image: .trashRed,
                 attributes: .destructive
             ) { [weak self] _ in
                 self?.action.accept(.delete(index: indexPath.item, title: item.urlMetadata.title))


### PR DESCRIPTION
## 📌 관련 이슈
close #390 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- BackButton 이미지 변경
- 폴더 추가 버튼 이미지 변경
- 클립 추가 버튼 이미지 변경
- 상세 정보 버튼 이미지 변경
- 편집 버튼 이미지 변경
- 삭제 버튼 이미지 변경

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/319dcf98-a188-457f-9df5-8112ad9a6ee2" width="250px"><img src="https://github.com/user-attachments/assets/17684bf5-5b20-4f9f-9b0b-fa8a8dd72020" width="250px"> |
