### PR TITLE
클립 편집 화면 저장 버튼 활성화 관련 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -45,6 +45,7 @@ extension EditClipViewController: View {
             .rx
             .text
             .orEmpty
+            .skip(1)
             .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
             .map { Reactor.Action.editURLTextField($0) }
             .bind(to: reactor.action)
@@ -135,6 +136,16 @@ extension EditClipViewController: View {
             .filter { $0 }
             .take(1)
             .map { _ in Reactor.Action.fetchTopLevelFolder }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        reactor.state
+            .map(\.urlString)
+            .take(1)
+            .filter { !$0.isEmpty }
+            .flatMap { urlString in
+                Observable.of(.editingURLTextField, .editURLTextField(urlString))
+            }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -293,21 +293,12 @@ extension EditClipViewController: View {
             .disposed(by: disposeBag)
 
         Observable.combineLatest(
-            reactor.state.map(\.clip),
-            reactor.state.map(\.memoText),
             reactor.state.map(\.isURLValid),
             reactor.state.map(\.currentFolder),
-            reactor.state.map(\.isLoading),
-            reactor.state.map(\.urlString)
+            reactor.state.map(\.isLoading)
         )
-        .map { clip, memoText, isURLValid, currentFolder, isLoading, urlText in
-            guard !isLoading else { return false }
-            guard isURLValid else { return false }
-            if let clip = clip {
-                return clip.memo != memoText || currentFolder?.id != clip.folderID || clip.urlMetadata.url.absoluteString != urlText
-            } else {
-                return currentFolder != nil
-            }
+        .map { isURLValid, currentFolder, isLoading in
+            !isLoading && isURLValid && currentFolder != nil
         }
         .distinctUntilChanged()
         .asDriver(onErrorDriveWith: .empty())


### PR DESCRIPTION
## 📌 관련 이슈

close #398 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- URL이 유효하고 선택된 폴더가 있을 경우에 저장 버튼이 활성화 되도록 수정
- 편집 또는 ShareExtension 시 전달 받은 URL 유효성 검사 수행되도록 수정

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/7912bed8-cf16-455c-8422-51383e9e4f13
