### PR TITLE
폴더 편집 시 텍스트 필드 비어있는 이슈 해결

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/ClipDetail/ViewController/ClipDetailViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/ClipDetail/ViewController/ClipDetailViewController.swift
@@ -70,10 +70,10 @@ private extension ClipDetailViewController {
 
         reactor.state
             .skip(1)
-            .map { (clip: $0.clip, clipDisplay: $0.clipDisplay, folderDisplay: $0.folderDisplay) }
-            .distinctUntilChanged { $0.clip.updatedAt == $1.clip.updatedAt }
+            .map { (clip: $0.clipDisplay, folder: $0.folderDisplay) }
+            .distinctUntilChanged { $0.clip == $1.clip }
             .observe(on: MainScheduler.instance)
-            .subscribe { [weak self] (_, clip, folder) in
+            .subscribe { [weak self] (clip, folder) in
                 guard let folder else { return }
                 self?.clipDetailView.setDisplay(clip, folder: folder)
             }

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -55,6 +55,7 @@ private extension EditFolderViewController {
             .disposed(by: disposeBag)
 
         editFolderView.folderTitleTextField.rx.text.orEmpty
+            .skip(1)
             .distinctUntilChanged()
             .map { .folderTitleChanged($0) }
             .bind(to: reactor.action)


### PR DESCRIPTION
## 📌 관련 이슈

close #401 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

폴더 편집 화면 전환 시 현재 폴더명이 보이도록 수정
