### PR TITLE
URLMetadataEntity에 screenshotData 속성 추가

### DIFF
--- a/Clipster/Clipster/Data/Model/Clipster.xcdatamodeld/.xccurrentversion
+++ b/Clipster/Clipster/Data/Model/Clipster.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>Clipster2.xcdatamodel</string>
+</dict>
+</plist>

--- a/Clipster/Clipster/Data/Model/Clipster.xcdatamodeld/Clipster2.xcdatamodel/contents
+++ b/Clipster/Clipster/Data/Model/Clipster.xcdatamodeld/Clipster2.xcdatamodel/contents
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="Clip" representedClassName="Clip" syncable="YES">
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="lastVisitedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="memo" attributeType="String" defaultValueString=""/>
+        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="folder" maxCount="1" deletionRule="Nullify" destinationEntity="Folder" inverseName="clips" inverseEntity="Folder"/>
+        <relationship name="urlMetadata" maxCount="1" deletionRule="Nullify" destinationEntity="URLMetadata" inverseName="clip" inverseEntity="URLMetadata"/>
+    </entity>
+    <entity name="Folder" representedClassName="Folder" syncable="YES">
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="depth" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="clips" toMany="YES" deletionRule="Nullify" destinationEntity="Clip" inverseName="folder" inverseEntity="Clip"/>
+        <relationship name="folders" toMany="YES" deletionRule="Nullify" destinationEntity="Folder" inverseName="parentFolder" inverseEntity="Folder"/>
+        <relationship name="parentFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Folder" inverseName="folders" inverseEntity="Folder"/>
+    </entity>
+    <entity name="URLMetadata" representedClassName="URLMetadata" syncable="YES">
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="depth" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thumbnailImageURLString" optional="YES" attributeType="String" defaultValueString=""/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="urlString" attributeType="String" defaultValueString=""/>
+        <relationship name="clip" maxCount="1" deletionRule="Nullify" destinationEntity="Clip" inverseName="urlMetadata" inverseEntity="Clip"/>
+    </entity>
+</model>

--- a/Clipster/Clipster/Data/Model/Clipster.xcdatamodeld/Clipster2.xcdatamodel/contents
+++ b/Clipster/Clipster/Data/Model/Clipster.xcdatamodeld/Clipster2.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="Clip" representedClassName="Clip" syncable="YES">
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -25,6 +25,7 @@
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="depth" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="screenshotData" optional="YES" attributeType="Binary"/>
         <attribute name="thumbnailImageURLString" optional="YES" attributeType="String" defaultValueString=""/>
         <attribute name="title" attributeType="String" defaultValueString=""/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>

--- a/Clipster/Clipster/Data/Model/URLMetadataEntity.swift
+++ b/Clipster/Clipster/Data/Model/URLMetadataEntity.swift
@@ -5,6 +5,7 @@ public class URLMetadataEntity: NSManagedObject {
     @NSManaged public var urlString: String
     @NSManaged public var title: String
     @NSManaged public var thumbnailImageURLString: String?
+    @NSManaged public var screenshotData: Data?
     @NSManaged public var createdAt: Date
     @NSManaged public var updatedAt: Date
     @NSManaged public var deletedAt: Date?

--- a/Clipster/Clipster/Data/Persistence/CoreDataStack.swift
+++ b/Clipster/Clipster/Data/Persistence/CoreDataStack.swift
@@ -18,6 +18,8 @@ final class CoreDataStack {
             forSecurityApplicationGroupIdentifier: appGroupID,
         ) {
             let storeURL = appGroupURL.appendingPathComponent("Clipster.sqlite")
+            print("\(Self.self): Store URL: \(storeURL)")
+
             let description = NSPersistentStoreDescription(url: storeURL)
             container.persistentStoreDescriptions = [description]
         } else {

--- a/Clipster/Clipster/Data/Persistence/DefaultClipStorage.swift
+++ b/Clipster/Clipster/Data/Persistence/DefaultClipStorage.swift
@@ -90,6 +90,7 @@ final class DefaultClipStorage: ClipStorage {
                 urlMetadataEntity.urlString = clip.urlMetadata.url.absoluteString
                 urlMetadataEntity.title = clip.urlMetadata.title
                 urlMetadataEntity.thumbnailImageURLString = clip.urlMetadata.thumbnailImageURL?.absoluteString
+                urlMetadataEntity.screenshotData = clip.urlMetadata.screenshotData
                 urlMetadataEntity.createdAt = clip.urlMetadata.createdAt
                 urlMetadataEntity.updatedAt = clip.urlMetadata.updatedAt
 
@@ -145,6 +146,7 @@ final class DefaultClipStorage: ClipStorage {
                     entity.urlMetadata?.urlString = clip.urlMetadata.url.absoluteString
                     entity.urlMetadata?.title = clip.urlMetadata.title
                     entity.urlMetadata?.thumbnailImageURLString = clip.urlMetadata.thumbnailImageURL?.absoluteString
+                    entity.urlMetadata?.screenshotData = clip.urlMetadata.screenshotData
                     entity.urlMetadata?.updatedAt = clip.urlMetadata.updatedAt
 
                     try context.save()

--- a/Clipster/Clipster/Data/Util/Mapper/DomainMapper.swift
+++ b/Clipster/Clipster/Data/Util/Mapper/DomainMapper.swift
@@ -46,6 +46,7 @@ struct DomainMapper {
             url: url,
             title: entity.title,
             thumbnailImageURL: URL(string: entity.thumbnailImageURLString ?? ""),
+            screenshotData: entity.screenshotData,
             createdAt: entity.createdAt,
             updatedAt: entity.updatedAt,
             deletedAt: entity.deletedAt,

--- a/Clipster/Clipster/Domain/Model/URLMetadata.swift
+++ b/Clipster/Clipster/Domain/Model/URLMetadata.swift
@@ -4,6 +4,7 @@ struct URLMetadata {
     let url: URL
     let title: String
     let thumbnailImageURL: URL?
+    let screenshotData: Data?
     let createdAt: Date
     let updatedAt: Date
     let deletedAt: Date?

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -151,6 +151,7 @@ final class EditClipReactor: Reactor {
                         url: urlMetadataDisplay.url,
                         title: urlMetadataDisplay.title,
                         thumbnailImageURL: urlMetadataDisplay.thumbnailImageURL,
+                        screenshotData: urlMetadataDisplay.screenshotImageData,
                         createdAt: clip.createdAt,
                         updatedAt: Date(),
                         deletedAt: clip.deletedAt
@@ -178,6 +179,7 @@ final class EditClipReactor: Reactor {
                         url: urlMetadata.url,
                         title: urlMetadata.title,
                         thumbnailImageURL: urlMetadata.thumbnailImageURL,
+                        screenshotData: urlMetadata.screenshotImageData,
                         createdAt: Date(),
                         updatedAt: Date(),
                         deletedAt: nil


### PR DESCRIPTION
## 📌 관련 이슈

close #404
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- CoreData DataModel 버전 추가
- URLMetadataEntity에 screenshotData 속성 추가(lightweight migration)
- Domain Layer의 URLMetadata에 screenshotData 속성 추가
- 스키마 변경에 따른 연계된 메서드들의 호출 수정

## 📌 구현 내역 스크린샷

<img width="1403" alt="image" src="https://github.com/user-attachments/assets/b180640d-5fa4-4d2c-b767-b1c9951c340e" />
