### PR TITLE
미리보기 뷰 썸네일 이미지 크기, 미리보기 미지원 시 저장 안 되는 오류 수정

### DIFF
--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -145,7 +145,7 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
 
         return ParsedURLMetadataDTO(
             url: url,
-            title: title,
+            title: title.isEmpty ? url.absoluteString : title,
             thumbnailImageURL: URL(string: thumbnailImageURL ?? ""),
             screenshotData: nil
         )

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -290,7 +290,7 @@ final class EditClipReactor: Reactor {
             }
         case .updateURLMetadata(let urlMetaDisplay):
             newState.urlMetadataDisplay = urlMetaDisplay
-            newState.isHiddenURLMetadataStackView = urlMetaDisplay?.title == nil
+            newState.isHiddenURLMetadataStackView = urlMetaDisplay?.thumbnailImageURL == nil && urlMetaDisplay?.screenshotImageData == nil
         case .updateIsTappedFolderView(let value):
             newState.isTappedFolderView = value
         case .updateCurrentFolder(let newFolder):


### PR DESCRIPTION
## 📌 관련 이슈

close #411 
close #412 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- title에 빈 문자열이 존재하여 비정상적인 썸네일 이미지 크기 문제 수정
- 미리보기 미지원 시 저장 안 되는 문제 수정
