### PR TITLE
앱 그룹 초기화 구문 임시 추가

### DIFF
--- a/Clipster/Clipster/App/Source/SceneDelegate.swift
+++ b/Clipster/Clipster/App/Source/SceneDelegate.swift
@@ -19,6 +19,12 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let windowScene = scene as? UIWindowScene else { return }
 
+        #if DEBUG
+        _ = UserDefaults(suiteName: "group.com.saltshaker.clipster.debug")
+        #else
+        _ = UserDefaults(suiteName: "group.com.saltshaker.clipster")
+        #endif
+
         let navigationController = UINavigationController()
         navigationController.isNavigationBarHidden = true
         let diContainer = DIContainer()


### PR DESCRIPTION
## 📌 관련 이슈

close #414
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

앱 설치 직후 1회에 한해 Share Extension이 작동하지 않는 이슈가 있는데, 앱 그룹을 좀 더 이른 시점에 초기화 해줌으로써 임시로 해결했습니다.

## 📌 참고 사항

차후에 앱을 실행하지 않고 Share Extension에서만 클립 추가를 할 수 있게 되면, 자연스럽게 삭제할 수 있을 것 같습니다.
