### PR TITLE
클립 편집화면 진입 시 유효성 검사

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -162,6 +162,20 @@ extension EditClipViewController: View {
 
         reactor.state
             .map(\.urlString)
+            .take(1)
+            .filter { !$0.isEmpty }
+            .flatMap { urlString in
+                Observable.of(
+                    .editingURLTextField,
+                    .editURLTextField(urlString),
+                    .validifyURL(urlString)
+                )
+            }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        reactor.state
+            .map(\.urlString)
             .distinctUntilChanged()
             .asDriver(onErrorJustReturn: "")
             .drive(editClipView.urlView.urlTextField.rx.text)


### PR DESCRIPTION
## 📌 관련 이슈

close #413 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

편집 화면 진입 시 전달된 URL에 대한 유효성 검사 진행하도록 수정

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/80ba1ea5-7c1c-4922-8fd4-0aa6f75f1485
