### PR TITLE
폴더 화면에서 Cell 탭할 시 올바른 IndexPath 전달하도록 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
@@ -395,7 +395,7 @@ private extension FolderView {
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] indexPath in
                 guard let self else { return }
-                action.accept(.didTapCell(indexPath))
+                action.accept(.didTapCell(logicalIndexPath(indexPath)))
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 📌 관련 이슈

close #417 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

폴더 section이 없을 경우, IndexPath.section이 의도한 대로 동작하지 않는 부분을 수정했습니다.

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/47a25791-2b5f-4047-9598-9c00e0395e78" width="250px"> |
