### PR TITLE
폴더 편집 시에는 포커스 이동 안 하도록 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -112,8 +112,8 @@ private extension EditFolderViewController {
 
         reactor.state
             .map { $0.folder == nil }
-            .take(1)
             .filter { $0 }
+            .take(1)
             .observe(on: MainScheduler.instance)
             .subscribe { [weak self] _ in
                 self?.editFolderView.folderTitleTextField.becomeFirstResponder()


### PR DESCRIPTION
## 📌 관련 이슈

close #422 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

폴더 편집 시에는 키보드가 올라오지 않도록 수정

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/692c859c-b305-40d6-8011-f8101ca5c5a6
