### PR TITLE
클립 편집 화면에서 폴더 변경 시 클립 상세 화면 갱신

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/ClipDetail/ViewController/ClipDetailViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/ClipDetail/ViewController/ClipDetailViewController.swift
@@ -57,8 +57,12 @@ private extension ClipDetailViewController {
     }
 
     func bindState(from reactor: Reactor) {
+        typealias Display = (clip: ClipDisplay, folder: FolderDisplay?)
+
         reactor.state
-            .map { (clip: $0.clipDisplay, folder: $0.folderDisplay) }
+            .map { state -> Display in
+                (clip: state.clipDisplay, folder: state.folderDisplay)
+            }
             .filter { $0.folder != nil }
             .take(1)
             .observe(on: MainScheduler.instance)
@@ -70,8 +74,12 @@ private extension ClipDetailViewController {
 
         reactor.state
             .skip(1)
-            .map { (clip: $0.clipDisplay, folder: $0.folderDisplay) }
-            .distinctUntilChanged { $0.clip == $1.clip }
+            .map { state -> Display in
+                (clip: state.clipDisplay, folder: state.folderDisplay)
+            }
+            .distinctUntilChanged { (lhs: Display, rhs: Display) in
+                lhs.clip == rhs.clip && lhs.folder == rhs.folder
+            }
             .observe(on: MainScheduler.instance)
             .subscribe { [weak self] (clip, folder) in
                 guard let folder else { return }


### PR DESCRIPTION
## 📌 관련 이슈

close #426 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

클립 편집화면에서 폴더 수정 후 클립 상세화면으로 돌아오면 수정된 폴더로 UI가 갱신되지 않음
-> `distinctUntilChanged` 로직 수정하여 갱신되도록 함

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/48c06bdc-3b55-4245-a85e-1af53eb05218
