### PR TITLE
HomeReactor 좀 더 선언형으로 리팩토링

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -36,6 +36,10 @@ final class DIContainer {
         DefaultUpdateClipUseCase(clipRepository: makeClipRepository())
     }
 
+    func makeVisitClipUseCase() -> VisitClipUseCase {
+        DefaultVisitClipUseCase(clipRepository: makeClipRepository())
+    }
+
     func makeDeleteClipUseCase() -> DeleteClipUseCase {
         DefaultDeleteClipUseCase(clipRepository: makeClipRepository())
     }
@@ -171,7 +175,7 @@ final class DIContainer {
             fetchTopLevelFoldersUseCase: makeFetchTopLevelFoldersUseCase(),
             deleteClipUseCase: makeDeleteClipUseCase(),
             deleteFolderUseCase: makeDeleteFolderUseCase(),
-            updateClipUseCase: makeUpdateClipUseCase()
+            visitClipUseCase: makeVisitClipUseCase()
         )
     }
 

--- a/Clipster/Clipster/Domain/Protocol/UseCase/Clip/VisitClipUseCase.swift
+++ b/Clipster/Clipster/Domain/Protocol/UseCase/Clip/VisitClipUseCase.swift
@@ -1,0 +1,3 @@
+protocol VisitClipUseCase {
+    func execute(clip: Clip) async -> Result<Void, Error>
+}

--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultVisitClipUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultVisitClipUseCase.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+final class DefaultVisitClipUseCase: VisitClipUseCase {
+    private let clipRepository: ClipRepository
+
+    init(clipRepository: ClipRepository) {
+        self.clipRepository = clipRepository
+    }
+
+    func execute(clip: Clip) async -> Result<Void, Error> {
+        let visitedClip = Clip(
+            id: clip.id,
+            folderID: clip.folderID,
+            urlMetadata: clip.urlMetadata,
+            memo: clip.memo,
+            lastVisitedAt: Date(),
+            createdAt: clip.createdAt,
+            updatedAt: Date(),
+            deletedAt: clip.deletedAt
+        )
+
+        return await clipRepository.updateClip(visitedClip).mapError { $0 as Error }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/Home/Reactor/HomeReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Reactor/HomeReactor.swift
@@ -57,20 +57,20 @@ final class HomeReactor: Reactor {
     private let fetchTopLevelFoldersUseCase: FetchTopLevelFoldersUseCase
     private let deleteClipUseCase: DeleteClipUseCase
     private let deleteFolderUseCase: DeleteFolderUseCase
-    private let updateClipUseCase: UpdateClipUseCase
+    private let visitClipUseCase: VisitClipUseCase
 
     init(
         fetchUnvisitedClipsUseCase: FetchUnvisitedClipsUseCase,
         fetchTopLevelFoldersUseCase: FetchTopLevelFoldersUseCase,
         deleteClipUseCase: DeleteClipUseCase,
         deleteFolderUseCase: DeleteFolderUseCase,
-        updateClipUseCase: UpdateClipUseCase
+        visitClipUseCase: VisitClipUseCase
     ) {
         self.fetchUnvisitedClipsUseCase = fetchUnvisitedClipsUseCase
         self.fetchTopLevelFoldersUseCase = fetchTopLevelFoldersUseCase
         self.deleteClipUseCase = deleteClipUseCase
         self.deleteFolderUseCase = deleteFolderUseCase
-        self.updateClipUseCase = updateClipUseCase
+        self.visitClipUseCase = visitClipUseCase
     }
 
     func mutate(action: Action) -> Observable<Mutation> {
@@ -128,8 +128,7 @@ final class HomeReactor: Reactor {
 
                 switch section {
                 case .unvisitedClip(let clip):
-                    let updatedClip = updateClipAsVisited(clip)
-                    _ = await updateClipUseCase.execute(clip: updatedClip)
+                    _ = await visitClipUseCase.execute(clip: clip)
                     return .setRoute(.showWebView(clip.urlMetadata.url))
                 case .folder(let folder):
                     return .setRoute(.showFolder(folder))
@@ -190,21 +189,6 @@ final class HomeReactor: Reactor {
             newState.phase = phase
         }
         return newState
-    }
-}
-
-private extension HomeReactor {
-    func updateClipAsVisited(_ clip: Clip) -> Clip {
-        Clip(
-            id: clip.id,
-            folderID: clip.folderID,
-            urlMetadata: clip.urlMetadata,
-            memo: clip.memo,
-            lastVisitedAt: Date(),
-            createdAt: clip.createdAt,
-            updatedAt: Date(),
-            deletedAt: clip.deletedAt
-        )
     }
 }
 

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -94,6 +94,7 @@ private extension HomeViewController {
         reactor.pulse(\.$route)
             .compactMap { $0 }
             .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
+            .observe(on: MainScheduler.instance)
             .bind { [weak self] route in
                 guard let self else { return }
 


### PR DESCRIPTION
## 📌 관련 이슈
close #436 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- Reactor 구조 좀 더 선언형으로 리팩토링
- VisitClipUseCase 분리

## 📌 PR Point
```swift
.catch { .just(.setPhase(.error($0.localizedDescription))) },
.just(.setPhase(.success))
````
- fromAsync가 제네릭이라 함수 내부에서 .setPhase(.success)까지 함께 반환할 수 없어, 결국 외부에서 무조건 .just(.setPhase(.success))를 붙이게 되어 에러가 나도 성공처럼 보이는 구조가 조금 어색하긴합니다. (결과적으로는 문제가 있진 않음)
- 컨벤션대로 하긴 했지만, 솔직히 재사용성도 떨어지고 가독성도 낮아진거 같습니다.
- 개선점이 있다면 피드백 부탁 드립니다.