### PR TITLE
EditClipView URL TextField Clear 버튼 클릭 시 UI 안정성 개선

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -119,10 +119,9 @@ final class EditClipReactor: Reactor {
             return .just(.updateURLString(trimmed))
         case .validifyURL(let text):
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            let parsedURL = Observable<Mutation>.fromAsync { [weak self] in
+            return .fromAsync { [weak self] in
                 guard let self else { return Observable<Mutation>.empty() }
                 let (metadata, isValidURL) = try await parseURLUseCase.execute(urlString: trimmed).get()
-
                 let clipValidType: ClipValidType
                 switch (metadata, isValidURL) {
                 case (.some, true):
@@ -132,10 +131,9 @@ final class EditClipReactor: Reactor {
                 case (_, false):
                     clipValidType = .invalid
                 }
-
-                return Observable.merge(
+                return .merge(
                     .just(Mutation.updateURLMetadata(toURLMetaDisplay(entity: metadata))),
-                    .just(Mutation.updateIsValidURL(clipValidType)),
+                    .just(Mutation.updateIsValidURL(clipValidType))
                 )
             }
             .flatMap { $0 }
@@ -158,7 +156,6 @@ final class EditClipReactor: Reactor {
                 }
                 return .empty()
             }
-            return parsedURL
         case .editingURLTextField:
             return .just(.updateIsLoading(true))
         case .editMemo(let text):

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -43,8 +43,9 @@ extension EditClipViewController: View {
     private func bindUI(to reactor: EditClipReactor) {
         editClipView.urlView.urlTextField
             .rx
-            .text
-            .orEmpty
+            .controlEvent(.editingChanged)
+            .withLatestFrom(editClipView.urlView.urlTextField.rx.text.orEmpty)
+            .distinctUntilChanged()
             .skip(1)
             .map { Reactor.Action.editURLTextField($0) }
             .bind(to: reactor.action)
@@ -56,15 +57,14 @@ extension EditClipViewController: View {
             .withLatestFrom(editClipView.urlView.urlTextField.rx.text.orEmpty)
             .skip(1)
             .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
-            .distinctUntilChanged()
             .map { Reactor.Action.validifyURL($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
         editClipView.urlView.urlTextField
             .rx
-            .text
-            .orEmpty
+            .controlEvent(.editingChanged)
+            .withLatestFrom(editClipView.urlView.urlTextField.rx.text.orEmpty)
             .distinctUntilChanged()
             .skip(1)
             .map { _ in Reactor.Action.editingURLTextField }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -52,10 +52,11 @@ extension EditClipViewController: View {
 
         editClipView.urlView.urlTextField
             .rx
-            .text
-            .orEmpty
+            .controlEvent(.editingChanged)
+            .withLatestFrom(editClipView.urlView.urlTextField.rx.text.orEmpty)
             .skip(1)
             .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
+            .distinctUntilChanged()
             .map { Reactor.Action.validifyURL($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 📌 관련 이슈

close #442 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) | 비고 |
| :-------------: | :----------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/ab3cd2be-0531-496d-bd1c-a0105c8042fd" width="250px"> | 뷰 진입 시 textField 내용이 바뀌지 않았음에도 URL 적합성이 반복 실행 됨 |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/b179b79b-9959-45f8-9b06-dbe27ac91bfa" width="250px"> | Clear 버튼 클릭 직후 textField에 포커싱하면 URLMetadata는 잔상이 남은 후 사라지고 URLValidation 데이터가 표시 됨  |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/1ee72391-da29-439b-8fc4-1556401cf1c3" width="250px"> | 실제 textField의 내용이 변경됐을 경우에만 바인딩 로직 수행, Clear 버튼 이후 UI 안정성 개선 |
