### PR TITLE
EditClipView 키보드 높이에 따른 동적 레이아웃 적용

### DIFF
--- a/Clipster/Clipster/Domain/UseCase/URL/DefaultParseURLUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/URL/DefaultParseURLUseCase.swift
@@ -13,6 +13,12 @@ final class DefaultParseURLUseCase: ParseURLUseCase {
 
         if lowercased.hasPrefix("https://") || lowercased.hasPrefix("http://") {
             correctedURLString = urlString
+        } else if lowercased.hasPrefix("https:/") || lowercased.hasPrefix("http:/") {
+            correctedURLString = lowercased.replacingOccurrences(of: "https:/", with: "https://")
+                .replacingOccurrences(of: "http:/", with: "https://")
+        } else if lowercased.hasPrefix("https:")  || lowercased.hasPrefix("http:") {
+            correctedURLString =  lowercased.replacingOccurrences(of: "https:", with: "https://")
+                .replacingOccurrences(of: "http:", with: "http://")
         } else {
             correctedURLString = "https://\(urlString)"
         }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -15,6 +15,7 @@ final class EditClipReactor: Reactor {
     }
 
     enum Action {
+        case viewDidAppear
         case editURLTextField(String)
         case validifyURL(String)
         case editingURLTextField
@@ -25,7 +26,6 @@ final class EditClipReactor: Reactor {
         case fetchFolder
         case fetchTopLevelFolder
         case disappearFolderSelectorView
-        case viewDidAppear
     }
 
     enum Mutation {

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -25,6 +25,7 @@ final class EditClipReactor: Reactor {
         case fetchFolder
         case fetchTopLevelFolder
         case disappearFolderSelectorView
+        case viewIsAppearing
     }
 
     enum Mutation {
@@ -36,6 +37,7 @@ final class EditClipReactor: Reactor {
         case updateCurrentFolder(Folder?)
         case updateIsSuccessedEditClip(Bool)
         case updateIsLoading(Bool)
+        case updateIsShowKeyboard(Bool)
     }
 
     struct State {
@@ -56,6 +58,7 @@ final class EditClipReactor: Reactor {
         var isURLValid = false
         var isTappedFolderView: Bool = false
         var isSuccessedEditClip: Bool = false
+        var isShowKeyboard: Bool = false
     }
 
     var initialState: State
@@ -242,6 +245,8 @@ final class EditClipReactor: Reactor {
             .catchAndReturn(.updateCurrentFolder(nil))
         case .disappearFolderSelectorView:
             return .just(.updateIsTappedFolderView(false))
+        case .viewIsAppearing:
+            return .just(.updateIsShowKeyboard(true))
         }
     }
 
@@ -299,6 +304,8 @@ final class EditClipReactor: Reactor {
             newState.urlValidationLabelText = "URL 분석 중..."
             newState.urlValidationImageName = nil
             newState.isHiddenURLValidationStackView = false
+        case .updateIsShowKeyboard(let value):
+            newState.isShowKeyboard = value
         }
         return newState
     }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -25,7 +25,7 @@ final class EditClipReactor: Reactor {
         case fetchFolder
         case fetchTopLevelFolder
         case disappearFolderSelectorView
-        case viewIsAppearing
+        case viewDidAppear
     }
 
     enum Mutation {
@@ -245,7 +245,7 @@ final class EditClipReactor: Reactor {
             .catchAndReturn(.updateCurrentFolder(nil))
         case .disappearFolderSelectorView:
             return .just(.updateIsTappedFolderView(false))
-        case .viewIsAppearing:
+        case .viewDidAppear:
             return .just(.updateIsShowKeyboard(true))
         }
     }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
@@ -102,7 +102,8 @@ private extension EditClipView {
         scrollView.snp.makeConstraints { make in
             make.top.equalTo(commonNavigationView.snp.bottom)
             make.directionalHorizontalEdges.equalToSuperview()
-            make.bottom.equalToSuperview()
+//            make.bottom.equalToSuperview()
+            make.bottom.equalTo(keyboardLayoutGuide.snp.top)
         }
 
         scrollContainerView.snp.makeConstraints { make in

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
@@ -12,7 +12,7 @@ final class EditClipView: UIView {
         return stackView
     }()
 
-    private let scrollView: UIScrollView = {
+    let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.showsHorizontalScrollIndicator = false
         return scrollView
@@ -102,8 +102,7 @@ private extension EditClipView {
         scrollView.snp.makeConstraints { make in
             make.top.equalTo(commonNavigationView.snp.bottom)
             make.directionalHorizontalEdges.equalToSuperview()
-//            make.bottom.equalToSuperview()
-            make.bottom.equalTo(keyboardLayoutGuide.snp.top)
+            make.bottom.equalToSuperview()
         }
 
         scrollContainerView.snp.makeConstraints { make in

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -141,6 +141,19 @@ extension EditClipViewController: View {
             }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+
+        NotificationCenter.default.rx.notification(UIResponder.keyboardWillChangeFrameNotification)
+            .observe(on: MainScheduler.instance)
+            .subscribe { [weak self] notification in
+                guard let self,
+                      let userInfo = notification.userInfo,
+                      let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+
+                let bottomInset = max(0, UIScreen.main.bounds.height - keyboardFrame.origin.y)
+                editClipView.scrollView.contentInset.bottom = bottomInset
+                editClipView.scrollView.verticalScrollIndicatorInsets.bottom = bottomInset
+            }
+            .disposed(by: disposeBag)
     }
 
     private func bindState(from reactor: EditClipReactor) {

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -32,6 +32,11 @@ final class EditClipViewController: UIViewController {
         super.viewWillAppear(animated)
         navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
+
+    override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
+        reactor?.action.onNext(.viewIsAppearing)
+    }
 }
 
 extension EditClipViewController: View {
@@ -140,8 +145,8 @@ extension EditClipViewController: View {
 
     private func bindState(from reactor: EditClipReactor) {
         reactor.state
-            .map { $0.type }
-            .filter { $0 == .create }
+            .map { ($0.type, $0.isShowKeyboard) }
+            .filter { $0 == .create && $1 }
             .take(1)
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] _ in

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -33,9 +33,9 @@ final class EditClipViewController: UIViewController {
         navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 
-    override func viewIsAppearing(_ animated: Bool) {
-        super.viewIsAppearing(animated)
-        reactor?.action.onNext(.viewIsAppearing)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        reactor?.action.onNext(.viewDidAppear)
     }
 }
 

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Reactor/EditFolderReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Reactor/EditFolderReactor.swift
@@ -3,6 +3,8 @@ import ReactorKit
 
 final class EditFolderReactor: Reactor {
     enum Action {
+        case viewIsAppearing
+        case viewWillDisappear
         case folderTitleChanged(String)
         case saveButtonTapped
         case clearButtonTapped
@@ -16,6 +18,7 @@ final class EditFolderReactor: Reactor {
         case setParentFolder(Folder?)
         case setPhase(State.Phase)
         case setRoute(State.Route?)
+        case updateIsShowKeyboard(Bool)
     }
 
     struct State {
@@ -25,6 +28,7 @@ final class EditFolderReactor: Reactor {
         var parentFolder: Folder?
         var parentFolderDisplay: FolderDisplay?
         var isSavable = false
+        var isShowKeyboard: Bool = false
 
         @Pulse var phase: Phase = .idle
         @Pulse var route: Route?
@@ -139,6 +143,10 @@ final class EditFolderReactor: Reactor {
             return .just(.setRoute(.showFolderSelector))
         case .folderSelectorDismissed:
             return .just(.setRoute(nil))
+        case .viewIsAppearing:
+            return .just(.updateIsShowKeyboard(true))
+        case .viewWillDisappear:
+            return .just(.updateIsShowKeyboard(false))
         }
     }
 
@@ -162,6 +170,9 @@ final class EditFolderReactor: Reactor {
         case .setRoute(let route):
             print("\(Self.self): Navigate to: \(route.debugDescription)")
             newState.route = route
+        case .updateIsShowKeyboard(let value):
+            print("\(Self.self): Show keyboard updated to: \(value)")
+            newState.isShowKeyboard = value
         }
 
         return newState

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Reactor/EditFolderReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Reactor/EditFolderReactor.swift
@@ -3,7 +3,7 @@ import ReactorKit
 
 final class EditFolderReactor: Reactor {
     enum Action {
-        case viewIsAppearing
+        case viewDidAppear
         case folderTitleChanged(String)
         case saveButtonTapped
         case clearButtonTapped
@@ -142,7 +142,7 @@ final class EditFolderReactor: Reactor {
             return .just(.setRoute(.showFolderSelector))
         case .folderSelectorDismissed:
             return .just(.setRoute(nil))
-        case .viewIsAppearing:
+        case .viewDidAppear:
             return .just(.updateIsShowKeyboard(true))
         }
     }

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Reactor/EditFolderReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Reactor/EditFolderReactor.swift
@@ -4,7 +4,6 @@ import ReactorKit
 final class EditFolderReactor: Reactor {
     enum Action {
         case viewIsAppearing
-        case viewWillDisappear
         case folderTitleChanged(String)
         case saveButtonTapped
         case clearButtonTapped
@@ -145,8 +144,6 @@ final class EditFolderReactor: Reactor {
             return .just(.setRoute(nil))
         case .viewIsAppearing:
             return .just(.updateIsShowKeyboard(true))
-        case .viewWillDisappear:
-            return .just(.updateIsShowKeyboard(false))
         }
     }
 

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -43,11 +43,6 @@ final class EditFolderViewController: UIViewController, View {
         reactor?.action.onNext(.viewIsAppearing)
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        reactor?.action.onNext(.viewWillDisappear)
-    }
-
     func bind(reactor: Reactor) {
         bindAction(to: reactor)
         bindState(from: reactor)
@@ -127,15 +122,6 @@ private extension EditFolderViewController {
             .observe(on: MainScheduler.instance)
             .subscribe { [weak self] _ in
                 self?.editFolderView.folderTitleTextField.becomeFirstResponder()
-            }
-            .disposed(by: disposeBag)
-
-        reactor.state
-            .filter { !$0.isShowKeyboard }
-            .skip(1)
-            .observe(on: MainScheduler.instance)
-            .subscribe { [weak self] _ in
-                self?.editFolderView.folderTitleTextField.resignFirstResponder()
             }
             .disposed(by: disposeBag)
 

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -38,9 +38,9 @@ final class EditFolderViewController: UIViewController, View {
         navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 
-    override func viewIsAppearing(_ animated: Bool) {
-        super.viewIsAppearing(animated)
-        reactor?.action.onNext(.viewIsAppearing)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        reactor?.action.onNext(.viewDidAppear)
     }
 
     func bind(reactor: Reactor) {


### PR DESCRIPTION
## 📌 관련 이슈

close #444 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 스크롤 뷰 키보드 동적 레이아웃

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) | 비고 |
| :-------------: | :----------: | :----------: |
| iPhone 16 Pro | <video src="https://github.com/user-attachments/assets/1d4738c7-95d8-40cc-8e7b-1d925b00ca1b" width="250px"> | 기존 문제가 생겼던 상황 |
| iPhone 16 Pro | <video src="https://github.com/user-attachments/assets/b5074cfe-8305-452a-a4a3-1d83c2879962" width="250px"> | 개선 이후 |

## 📌 참고 사항

- ~viewDidLoad에서 동작했던 textField 포커싱(키보드 올리기)를 viewIsAppearing으로 하는 것이 더 적합하여 변경 했습니다.~
- 애니메이션이랑 헷갈렸네요 viewDidAppear로 수정하고 다시 푸시하겠습니다
- base 브랜치가 dev가 아니라 #478 부터 확인 부탁드립니다.