### PR TITLE
FolderReactor 리팩터링

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -178,7 +178,7 @@ final class DIContainer {
             folder: folder,
             fetchFolderUseCase: makeFetchFolderUseCase(),
             deleteFolderUseCase: makeDeleteFolderUseCase(),
-            updateClipUseCase: makeUpdateClipUseCase(),
+            visitClipUseCase: makeVisitClipUseCase(),
             deleteClipUseCase: makeDeleteClipUseCase(),
         )
     }

--- a/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
@@ -84,7 +84,6 @@ final class FolderReactor: Reactor {
                 isFirstAppear = false
                 return .empty()
             }
-
             return .concat(
                 .just(.setPhase(.loading)),
                 .fromAsync { [weak self] in
@@ -92,14 +91,11 @@ final class FolderReactor: Reactor {
                         let message = DomainError.unknownError.localizedDescription
                         return .setPhase(.error(message))
                     }
-
-                    let result = await fetchFolderUseCase.execute(id: folder.id)
-                    switch result {
-                    case .success(let folder):
-                        return .reloadFolder(folder)
-                    case .failure(let error):
-                        return .setPhase(.error(error.localizedDescription))
-                    }
+                    let folder = try await fetchFolderUseCase.execute(id: folder.id).get()
+                    return .reloadFolder(folder)
+                }
+                .catch { error in
+                    .just(.setPhase(.error(error.localizedDescription)))
                 },
                 .just(.setPhase(.success)),
             )
@@ -117,27 +113,22 @@ final class FolderReactor: Reactor {
                             let message = DomainError.unknownError.localizedDescription
                             return .setPhase(.error(message))
                         }
-
-                        let result = await visitClipUseCase.execute(clip: clip)
-                        if case .failure(let error) = result {
-                            return .setPhase(.error(error.localizedDescription))
-                        }
-
+                        _ = try await visitClipUseCase.execute(clip: clip).get()
                         return .setPhase(.success)
+                    }
+                    .catch { error in
+                        .just(.setPhase(.error(error.localizedDescription)))
                     },
                     .fromAsync { [weak self] in
                         guard let self else {
                             let message = DomainError.unknownError.localizedDescription
                             return .setPhase(.error(message))
                         }
-
-                        let result = await fetchFolderUseCase.execute(id: folder.id)
-                        switch result {
-                        case .success(let folder):
-                            return .reloadFolder(folder)
-                        case .failure(let error):
-                            return .setPhase(.error(error.localizedDescription))
-                        }
+                        let folder = try await fetchFolderUseCase.execute(id: folder.id).get()
+                        return .reloadFolder(folder)
+                    }
+                    .catch { error in
+                        .just(.setPhase(.error(error.localizedDescription)))
                     },
                     .just(.setRoute(.webView(clip.url))),
                     .just(.setPhase(.success)),
@@ -176,25 +167,20 @@ final class FolderReactor: Reactor {
                         let message = DomainError.unknownError.localizedDescription
                         return .setPhase(.error(message))
                     }
-
                     switch indexPath.section {
                     case 0:
                         let folder = folder.folders[indexPath.item]
-                        let result = await deleteFolderUseCase.execute(folder)
-                        if case .failure(let error) = result {
-                            return .setPhase(.error(error.localizedDescription))
-                        }
+                        _ = try await deleteFolderUseCase.execute(folder).get()
                     case 1:
                         let clip = folder.clips[indexPath.item]
-                        let result = await deleteClipUseCase.execute(clip)
-                        if case .failure(let error) = result {
-                            return .setPhase(.error(error.localizedDescription))
-                        }
+                        _ = try await deleteClipUseCase.execute(clip).get()
                     default:
                         return .setPhase(.error("Invalid section index"))
                     }
-
                     return .setPhase(.success)
+                }
+                .catch { error in
+                    .just(.setPhase(.error(error.localizedDescription)))
                 },
                 .just(.setPhase(.loading)),
                 .fromAsync { [weak self] in
@@ -202,14 +188,11 @@ final class FolderReactor: Reactor {
                         let message = DomainError.unknownError.localizedDescription
                         return .setPhase(.error(message))
                     }
-
-                    let result = await fetchFolderUseCase.execute(id: folder.id)
-                    switch result {
-                    case .success(let folder):
-                        return .reloadFolder(folder)
-                    case .failure(let error):
-                        return .setPhase(.error(error.localizedDescription))
-                    }
+                    let folder = try await fetchFolderUseCase.execute(id: folder.id).get()
+                    return .reloadFolder(folder)
+                }
+                .catch { error in
+                    .just(.setPhase(.error(error.localizedDescription)))
                 },
                 .just(.setPhase(.success)),
             )

--- a/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
@@ -105,7 +105,6 @@ final class FolderReactor: Reactor {
                 return .concat(
                     .just(.setPhase(.loading)),
                     visitClipMutation(clip),
-                    reloadFolderMutation(),
                     .just(.setRoute(.webView(clip.url))),
                     .just(.setPhase(.success)),
                 )

--- a/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
@@ -42,20 +42,20 @@ final class FolderReactor: Reactor {
 
     private let fetchFolderUseCase: FetchFolderUseCase
     private let deleteFolderUseCase: DeleteFolderUseCase
-    private let updateClipUseCase: UpdateClipUseCase
+    private let visitClipUseCase: VisitClipUseCase
     private let deleteClipUseCase: DeleteClipUseCase
 
     init(
         folder: Folder,
         fetchFolderUseCase: FetchFolderUseCase,
         deleteFolderUseCase: DeleteFolderUseCase,
-        updateClipUseCase: UpdateClipUseCase,
+        visitClipUseCase: VisitClipUseCase,
         deleteClipUseCase: DeleteClipUseCase,
     ) {
         self.folder = folder
         self.fetchFolderUseCase = fetchFolderUseCase
         self.deleteFolderUseCase = deleteFolderUseCase
-        self.updateClipUseCase = updateClipUseCase
+        self.visitClipUseCase = visitClipUseCase
         self.deleteClipUseCase = deleteClipUseCase
 
         initialState = State(
@@ -92,21 +92,8 @@ final class FolderReactor: Reactor {
                     .fromAsync { [weak self] in
                         guard let self else { throw DomainError.unknownError }
                         let clip = folder.clips[indexPath.item]
-                        let updatedClip = Clip(
-                            id: clip.id,
-                            folderID: clip.folderID,
-                            url: clip.url,
-                            title: clip.title,
-                            memo: clip.memo,
-                            thumbnailImageURL: clip.thumbnailImageURL,
-                            screenshotData: clip.screenshotData,
-                            createdAt: clip.createdAt,
-                            lastVisitedAt: Date.now,
-                            updatedAt: Date.now,
-                            deletedAt: clip.deletedAt,
-                        )
-                        _ = await updateClipUseCase.execute(clip: updatedClip)
-                        return updatedClip
+                        _ = await visitClipUseCase.execute(clip: clip)
+                        return clip
                     }
                     .map { .updateClipLastVisitedDate($0) }
                     .catch { _ in .empty() },

--- a/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
@@ -102,7 +102,7 @@ final class FolderReactor: Reactor {
                         return .setPhase(.error(error.localizedDescription))
                     }
                 },
-                .just(.setPhase(.idle)),
+                .just(.setPhase(.success)),
             )
         case .didTapCell(let indexPath):
             switch indexPath.section {
@@ -128,7 +128,7 @@ final class FolderReactor: Reactor {
                         }
                     },
                     .just(.setRoute(.webView(clip.url))),
-                    .just(.setPhase(.idle)),
+                    .just(.setPhase(.success)),
                 )
             default:
                 return .empty()
@@ -199,7 +199,7 @@ final class FolderReactor: Reactor {
                         return .setPhase(.error(error.localizedDescription))
                     }
                 },
-                .just(.setPhase(.idle)),
+                .just(.setPhase(.success)),
             )
         }
     }

--- a/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
@@ -15,7 +15,6 @@ final class FolderReactor: Reactor {
     enum Mutation {
         case reloadFolder(Folder)
         case updateClipLastVisitedDate(Clip)
-        case delete
         case setPhase(Phase)
         case setRoute(Route)
     }
@@ -219,8 +218,6 @@ final class FolderReactor: Reactor {
             if let index = newState.clips.firstIndex(where: { $0.id == updatedClip.id }) {
                 newState.clips[index] = ClipDisplayMapper.map(updatedClip)
             }
-        case .delete:
-            break
         case .setPhase(let phase):
             newState.phase = phase
         case .setRoute(let route):


### PR DESCRIPTION
## 📌 관련 이슈

close #508 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- 클립 방문 시, UpdateUseCase가 아닌 VisitUseCase를 사용하도록 변경
- 향후 Activity Indictor와 Error Alert 구현을 위한 Phase 속성 추가
- State를 직접 변경하지 않았기 때문에, 적절하지 않았던 delete mutation case 제거
- 위 변경에 따른 DIContainer 수정

## 📌 참고 사항

FolderView에 ActivityIndicator와 ErrorAlert를 추가하는 작업은 별도 Task로 진행하겠습니다.
