### PR TITLE
FolderView UI 개선

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/ClipDetail/ViewController/ClipDetailViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/ClipDetail/ViewController/ClipDetailViewController.swift
@@ -100,7 +100,7 @@ private extension ClipDetailViewController {
                 case .success:
                     self.navigationController?.popViewController(animated: true)
                 case .error(let message):
-                    self.presentAlert(message: message)
+                    self.presentErrorAlert(message: message)
                 }
             }
             .disposed(by: disposeBag)
@@ -122,14 +122,6 @@ private extension ClipDetailViewController {
                 }
             }
             .disposed(by: disposeBag)
-    }
-}
-
-private extension ClipDetailViewController {
-    func presentAlert(message: String) {
-        let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "확인", style: .default))
-        present(alert, animated: true)
     }
 }
 

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -139,7 +139,7 @@ private extension EditFolderViewController {
                     self.onAdditionComplete?(folder)
                     self.navigationController?.popViewController(animated: true)
                 case .error(let message):
-                    self.presentAlert(message: message)
+                    self.presentErrorAlert(message: message)
                 }
             }
             .disposed(by: disposeBag)
@@ -163,14 +163,6 @@ private extension EditFolderViewController {
                 }
             }
             .disposed(by: disposeBag)
-    }
-}
-
-private extension EditFolderViewController {
-    func presentAlert(message: String) {
-        let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "확인", style: .default))
-        self.present(alert, animated: true)
     }
 }
 

--- a/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
@@ -73,6 +73,12 @@ final class FolderView: UIView {
         return button
     }()
 
+    private let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
@@ -107,6 +113,14 @@ final class FolderView: UIView {
     func setDisplay(isHidden: Bool) {
         emptyView.isHidden = isHidden
         emptyAddButton.isHidden = isHidden
+    }
+
+    func setLoading(_ isLoading: Bool) {
+        if isLoading {
+            activityIndicator.startAnimating()
+        } else {
+            activityIndicator.stopAnimating()
+        }
     }
 }
 
@@ -293,7 +307,7 @@ private extension FolderView {
     }
 
     func setHierarchy() {
-        [navigationView, collectionView, emptyView, emptyAddButton].forEach {
+        [navigationView, collectionView, emptyView, emptyAddButton, activityIndicator].forEach {
             addSubview($0)
         }
     }
@@ -329,6 +343,10 @@ private extension FolderView {
             make.width.equalTo(160)
             make.height.equalTo(48)
             make.centerX.equalToSuperview()
+        }
+
+        activityIndicator.snp.makeConstraints { make in
+            make.center.equalToSuperview()
         }
     }
 

--- a/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
@@ -73,11 +73,7 @@ final class FolderView: UIView {
         return button
     }()
 
-    private let activityIndicator: UIActivityIndicatorView = {
-        let indicator = UIActivityIndicatorView(style: .large)
-        indicator.hidesWhenStopped = true
-        return indicator
-    }()
+    private let activityIndicator = UIActivityIndicatorView(style: .large)
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
@@ -110,7 +110,7 @@ private extension FolderViewController {
                 case .loading:
                     folderView.setLoading(true)
                 case .error(let message):
-                    print(message) // TODO: 구현 필요
+                    presentErrorAlert(message: message)
                 }
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
@@ -97,6 +97,23 @@ private extension FolderViewController {
                 folderView.setDisplay(isHidden: isHidden)
             }
             .disposed(by: disposeBag)
+
+        reactor.pulse(\.$phase)
+            .compactMap { $0 }
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] phase in
+                guard let self else { return }
+
+                switch phase {
+                case .idle, .success:
+                    folderView.setLoading(false)
+                case .loading:
+                    folderView.setLoading(true)
+                case .error(let message):
+                    print(message) // TODO: 구현 필요
+                }
+            }
+            .disposed(by: disposeBag)
     }
 
     func bindRoute(from reactor: FolderReactor) {

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -81,9 +81,7 @@ private extension HomeViewController {
                     homeView.hideLoading()
                 case .error(let message):
                     homeView.hideLoading()
-                    let alert = UIAlertController(title: "에러", message: message, preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: "확인", style: .default))
-                    present(alert, animated: true)
+                    presentErrorAlert(message: message)
                 case .idle:
                     break
                 }

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
@@ -78,9 +78,7 @@ extension UnvisitedClipListViewController {
                     unvisitedClipListView.hideLoading()
                 case .error(let message):
                     unvisitedClipListView.hideLoading()
-                    let alert = UIAlertController(title: "에러", message: message, preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: "확인", style: .default))
-                    present(alert, animated: true)
+                    presentErrorAlert(message: message)
                 case .idle:
                     break
                 }

--- a/Clipster/Clipster/Presentation/Util/Extension/UIViewController+Extension.swift
+++ b/Clipster/Clipster/Presentation/Util/Extension/UIViewController+Extension.swift
@@ -11,6 +11,20 @@ extension UIViewController {
         view.endEditing(true)
     }
 
+    func presentErrorAlert(
+        message: String = "예기치 않은 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
+    ) {
+        let alert = UIAlertController(
+            title: "오류",
+            message: message,
+            preferredStyle: .alert
+        )
+        let confirmAction = UIAlertAction(title: "확인", style: .default)
+        alert.addAction(confirmAction)
+
+        present(alert, animated: true)
+    }
+
     func presentDeleteAlert(
         title: String,
         message: String = "삭제하겠습니까?",


### PR DESCRIPTION
## 📌 관련 이슈

close #511 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- FolderReactor의 Phase 변경에 따른 ActivityIndicator와 ErrorAlert 구현
- ErrorAlert의 경우 UIViewController+Extension에 구현해서 재사용할 수 있도록 구현했습니다.

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/51da3cd5-53bd-4b6a-84c9-25b8227a41b3" width="250px"> |

https://github.com/user-attachments/assets/ccd8d556-8b26-40b6-9412-1301dad57bca

## 📌 참고 사항

Error Alert를 독립적으로 구현한 다른 화면들에도 같이 적용했습니다.
수정된 화면: Folder, ClipDetail, EditFolder, Home, UnvisitedClipList