### PR TITLE
Description UI 적용

### DIFF
--- a/Clipster/Clipster/Data/Util/Mapper/DomainMapper.swift
+++ b/Clipster/Clipster/Data/Util/Mapper/DomainMapper.swift
@@ -32,6 +32,7 @@ struct DomainMapper {
             folderID: folderID,
             url: url,
             title: urlMetadataEntity.title,
+            description: " ",
             memo: entity.memo,
             thumbnailImageURL: URL(string: urlMetadataEntity.thumbnailImageURLString ?? ""),
             screenshotData: urlMetadataEntity.screenshotData,

--- a/Clipster/Clipster/Domain/Model/Entity/Clip.swift
+++ b/Clipster/Clipster/Domain/Model/Entity/Clip.swift
@@ -5,6 +5,7 @@ struct Clip {
     let folderID: UUID
     let url: URL
     let title: String
+    let description: String
     let memo: String
     let thumbnailImageURL: URL?
     let screenshotData: Data?

--- a/Clipster/Clipster/Domain/Model/URLMetadata.swift
+++ b/Clipster/Clipster/Domain/Model/URLMetadata.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-struct URLMetadata {
-    let url: URL
-    let title: String
-    let description: String
-    let thumbnailImageURL: URL?
-    let screenshotData: Data?
-}

--- a/Clipster/Clipster/Domain/Model/URLMetadata.swift
+++ b/Clipster/Clipster/Domain/Model/URLMetadata.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct URLMetadata {
+    let url: URL
+    let title: String
+    let description: String
+    let thumbnailImageURL: URL?
+    let screenshotData: Data?
+}

--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultDeleteClipUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultDeleteClipUseCase.swift
@@ -13,6 +13,7 @@ final class DefaultDeleteClipUseCase: DeleteClipUseCase {
             folderID: clip.folderID,
             url: clip.url,
             title: clip.title,
+            description: clip.description,
             memo: clip.memo,
             thumbnailImageURL: clip.thumbnailImageURL,
             screenshotData: clip.screenshotData,

--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultVisitClipUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultVisitClipUseCase.swift
@@ -13,6 +13,7 @@ final class DefaultVisitClipUseCase: VisitClipUseCase {
             folderID: clip.folderID,
             url: clip.url,
             title: clip.title,
+            description: clip.description,
             memo: clip.memo,
             thumbnailImageURL: clip.thumbnailImageURL,
             screenshotData: clip.screenshotData,

--- a/Clipster/Clipster/Presentation/Model/URLMetadataDisplay.swift
+++ b/Clipster/Clipster/Presentation/Model/URLMetadataDisplay.swift
@@ -3,6 +3,7 @@ import Foundation
 struct URLMetadataDisplay: Hashable {
     let url: URL
     let title: String
+    let description: String
     let thumbnailImageURL: URL?
     let screenshotImageData: Data?
 }

--- a/Clipster/Clipster/Presentation/Scene/Common/StackView/URLMetadataStackView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/StackView/URLMetadataStackView.swift
@@ -31,6 +31,15 @@ final class URLMetadataStackView: UIStackView {
         return label
     }()
 
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = .pretendard(size: 14, weight: .medium)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 2
+        label.text = " "
+        return label
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
@@ -42,7 +51,8 @@ final class URLMetadataStackView: UIStackView {
 
     func setDisplay(display: URLMetadataDisplay) {
         titleLabel.text = display.title
-        
+        descriptionLabel.text = display.description
+
         if let thumbnailURL = display.thumbnailImageURL {
             thumbnailImageView.kf.setImage(with: thumbnailURL)
         } else if let screenshotImageData = display.screenshotImageData,
@@ -84,7 +94,7 @@ private extension URLMetadataStackView {
             addArrangedSubview($0)
         }
 
-        [titleLabel].forEach {
+        [titleLabel, descriptionLabel].forEach {
             infoStackView.addArrangedSubview($0)
         }
     }

--- a/Clipster/Clipster/Presentation/Scene/Common/StackView/URLMetadataStackView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/StackView/URLMetadataStackView.swift
@@ -42,7 +42,7 @@ final class URLMetadataStackView: UIStackView {
 
     func setDisplay(display: URLMetadataDisplay) {
         titleLabel.text = display.title
-
+        
         if let thumbnailURL = display.thumbnailImageURL {
             thumbnailImageView.kf.setImage(with: thumbnailURL)
         } else if let screenshotImageData = display.screenshotImageData,

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -181,7 +181,7 @@ final class EditClipReactor: Reactor {
                     folderID: currentFolder.id,
                     url: urlMetadataDisplay.url,
                     title: urlMetadataDisplay.title,
-                    description:urlMetadataDisplay.description,
+                    description: urlMetadataDisplay.description,
                     memo: currentState.memoText,
                     thumbnailImageURL: urlMetadataDisplay.thumbnailImageURL,
                     screenshotData: urlMetadataDisplay.screenshotImageData,

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -181,6 +181,7 @@ final class EditClipReactor: Reactor {
                     folderID: currentFolder.id,
                     url: urlMetadataDisplay.url,
                     title: urlMetadataDisplay.title,
+                    description:urlMetadataDisplay.description,
                     memo: currentState.memoText,
                     thumbnailImageURL: urlMetadataDisplay.thumbnailImageURL,
                     screenshotData: urlMetadataDisplay.screenshotImageData,
@@ -197,16 +198,17 @@ final class EditClipReactor: Reactor {
             case .create, .shareExtension:
                 print("\(Self.self) save clip")
                 guard let currentFolder = currentState.currentFolder else { return .empty() }
-                guard let urlMetadata = currentState.urlMetadataDisplay else { return .empty() }
+                guard let urlMetadataDisplay = currentState.urlMetadataDisplay else { return .empty() }
 
                 let newClip = Clip(
                     id: UUID(),
                     folderID: currentFolder.id,
-                    url: urlMetadata.url,
-                    title: urlMetadata.title,
+                    url: urlMetadataDisplay.url,
+                    title: urlMetadataDisplay.title,
+                    description: urlMetadataDisplay.description,
                     memo: currentState.memoText,
-                    thumbnailImageURL: urlMetadata.thumbnailImageURL,
-                    screenshotData: urlMetadata.screenshotImageData,
+                    thumbnailImageURL: urlMetadataDisplay.thumbnailImageURL,
+                    screenshotData: urlMetadataDisplay.screenshotImageData,
                     createdAt: Date.now,
                     lastVisitedAt: nil,
                     updatedAt: Date.now,
@@ -310,6 +312,7 @@ private extension EditClipReactor {
             URLMetadataDisplay(
                 url: $0.url,
                 title: $0.title,
+                description: $0.description,
                 thumbnailImageURL: $0.thumbnailImageURL,
                 screenshotImageData: $0.screenshotData
             )
@@ -321,6 +324,7 @@ private extension EditClipReactor {
         return URLMetadataDisplay(
             url: url,
             title: url.absoluteString,
+            description: "내용 없음",
             thumbnailImageURL: nil,
             screenshotImageData: nil
         )

--- a/Clipster/Clipster/Presentation/Util/Mapper/ClipDisplayMapper.swift
+++ b/Clipster/Clipster/Presentation/Util/Mapper/ClipDisplayMapper.swift
@@ -5,8 +5,9 @@ struct ClipDisplayMapper {
         let urlMetadataDisplay = URLMetadataDisplay(
             url: clip.url,
             title: clip.title.isEmpty ? " " : clip.title,
+            description: clip.description.isEmpty ? " " : clip.description,
             thumbnailImageURL: clip.thumbnailImageURL,
-            screenshotImageData: clip.screenshotData,
+            screenshotImageData: clip.screenshotData
         )
 
         return ClipDisplay(


### PR DESCRIPTION
## 📌 관련 이슈

close #501 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- URLMetadataStackView / URLMetadataDisplay description 프로퍼티 추가

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/073aaba4-ac21-4e01-a300-e170f89fbba8" width="250px"> |

## 📌 참고 사항

- 현재 UI는 EditClipView에서만 적용되고 있습니다.
- 추후에 CoreData에 Description이 포함된 이후에 다른 뷰(description을 포함한 클립이 생성된다면)에서도 UI 적용 가능할 것입니다.