### PR TITLE
폴더 없이도 클립이 저장될 수 있도록 변경

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -69,6 +69,10 @@ final class DIContainer {
         DefaultFetchClipUseCase(clipRepository: makeClipRepository())
     }
 
+    func makeFetchTopLevelClipsUseCase() -> FetchTopLevelClipsUseCase {
+        DefaultFetchTopLevelClipsUseCase(clipRepository: makeClipRepository())
+    }
+
     func makeFetchUnvisitedClipsUseCase() -> FetchUnvisitedClipsUseCase {
         DefaultFetchUnvisitedClipsUseCase(clipRepository: makeClipRepository())
     }

--- a/Clipster/Clipster/Data/Persistence/DefaultClipStorage.swift
+++ b/Clipster/Clipster/Data/Persistence/DefaultClipStorage.swift
@@ -91,20 +91,25 @@ final class DefaultClipStorage: ClipStorage {
                 entity.createdAt = clip.createdAt
                 entity.updatedAt = clip.updatedAt
 
-                let request = FolderEntity.fetchRequest()
-                request.predicate = NSPredicate(format: "id == %@ AND deletedAt == nil", clip.folderID as CVarArg)
-                request.fetchLimit = 1
+                if let folderID = clip.folderID {
+                    let request = FolderEntity.fetchRequest()
+                    request.predicate = NSPredicate(
+                        format: "id == %@ AND deletedAt == nil",
+                        folderID as CVarArg,
+                    )
+                    request.fetchLimit = 1
 
-                do {
-                    guard let parentEntity = try context.fetch(request).first else {
-                        print("\(Self.self): ❌ Failed to insert: Parent entity not found")
-                        continuation.resume(returning: .failure(.entityNotFound))
-                        return
+                    do {
+                        guard let parentEntity = try context.fetch(request).first else {
+                            print("\(Self.self): ❌ Failed to insert: Parent entity not found")
+                            continuation.resume(returning: .failure(.entityNotFound))
+                            return
+                        }
+                        entity.folder = parentEntity
+                    } catch {
+                        print("\(Self.self): ❌ Failed to insert: \(error.localizedDescription)")
+                        continuation.resume(returning: .failure(.insertFailed(error.localizedDescription)))
                     }
-                    entity.folder = parentEntity
-                } catch {
-                    print("\(Self.self): ❌ Failed to insert: \(error.localizedDescription)")
-                    continuation.resume(returning: .failure(.insertFailed(error.localizedDescription)))
                 }
 
                 let urlMetadataEntity = URLMetadataEntity(context: context)
@@ -149,19 +154,23 @@ final class DefaultClipStorage: ClipStorage {
                     entity.updatedAt = clip.updatedAt
 
                     if entity.folder?.id != clip.folderID {
-                        let request = FolderEntity.fetchRequest()
-                        request.predicate = NSPredicate(
-                            format: "id == %@ AND deletedAt == nil",
-                            clip.folderID as CVarArg,
-                        )
-                        request.fetchLimit = 1
+                        if let folderID = clip.folderID {
+                            let request = FolderEntity.fetchRequest()
+                            request.predicate = NSPredicate(
+                                format: "id == %@ AND deletedAt == nil",
+                                folderID as CVarArg,
+                            )
+                            request.fetchLimit = 1
 
-                        guard let folderEntity = try context.fetch(request).first else {
-                            print("\(Self.self): ❌ Failed to update: Parent entity not found")
-                            continuation.resume(returning: .failure(.entityNotFound))
-                            return
+                            guard let folderEntity = try context.fetch(request).first else {
+                                print("\(Self.self): ❌ Failed to update: Parent entity not found")
+                                continuation.resume(returning: .failure(.entityNotFound))
+                                return
+                            }
+                            entity.folder = folderEntity
+                        } else {
+                            entity.folder = nil
                         }
-                        entity.folder = folderEntity
                     }
 
                     entity.urlMetadata?.urlString = clip.url.absoluteString

--- a/Clipster/Clipster/Data/Protocol/Persistence/ClipStorage.swift
+++ b/Clipster/Clipster/Data/Protocol/Persistence/ClipStorage.swift
@@ -2,6 +2,7 @@ import Foundation
 
 protocol ClipStorage {
     func fetchClip(by id: UUID) async -> Result<Clip, CoreDataError>
+    func fetchTopLevelClips() async -> Result<[Clip], CoreDataError>
     func fetchUnvisitedClips() async -> Result<[Clip], CoreDataError>
     func insertClip(_ clip: Clip) async -> Result<Void, CoreDataError>
     func updateClip(_ clip: Clip) async -> Result<Void, CoreDataError>

--- a/Clipster/Clipster/Data/Repository/Clip/DefaultClipRepository.swift
+++ b/Clipster/Clipster/Data/Repository/Clip/DefaultClipRepository.swift
@@ -12,6 +12,11 @@ final class DefaultClipRepository: ClipRepository {
             .mapError { _ in .unknownError }
     }
 
+    func fetchTopLevelClips() async -> Result<[Clip], DomainError> {
+        await storage.fetchTopLevelClips()
+            .mapError { _ in .unknownError }
+    }
+
     func fetchUnvisitedClips() async -> Result<[Clip], DomainError> {
         await storage.fetchUnvisitedClips()
             .mapError { _ in .unknownError }

--- a/Clipster/Clipster/Domain/Model/Entity/Clip.swift
+++ b/Clipster/Clipster/Domain/Model/Entity/Clip.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct Clip {
     let id: UUID
-    let folderID: UUID
+    let folderID: UUID?
     let url: URL
     let title: String
     let description: String

--- a/Clipster/Clipster/Domain/Protocol/Repository/Clip/ClipRepository.swift
+++ b/Clipster/Clipster/Domain/Protocol/Repository/Clip/ClipRepository.swift
@@ -2,6 +2,7 @@ import Foundation
 
 protocol ClipRepository {
     func fetchClip(by id: UUID) async -> Result<Clip, DomainError>
+    func fetchTopLevelClips() async -> Result<[Clip], DomainError>
     func fetchUnvisitedClips() async -> Result<[Clip], DomainError>
     func createClip(_ clip: Clip) async -> Result<Void, DomainError>
     func updateClip(_ clip: Clip) async -> Result<Void, DomainError>

--- a/Clipster/Clipster/Domain/Protocol/UseCase/Clip/FetchTopLevelClipsUseCase.swift
+++ b/Clipster/Clipster/Domain/Protocol/UseCase/Clip/FetchTopLevelClipsUseCase.swift
@@ -1,0 +1,3 @@
+protocol FetchTopLevelClipsUseCase {
+    func execute() async -> Result<[Clip], Error>
+}

--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultFetchTopLevelClipsUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultFetchTopLevelClipsUseCase.swift
@@ -1,0 +1,15 @@
+final class DefaultFetchTopLevelClipsUseCase: FetchTopLevelClipsUseCase {
+    private let clipRepository: ClipRepository
+
+    init(clipRepository: ClipRepository) {
+        self.clipRepository = clipRepository
+    }
+
+    func execute() async -> Result<[Clip], Error> {
+        await clipRepository.fetchTopLevelClips()
+            .map { clips in
+                clips.sorted { $0.createdAt > $1.createdAt }
+            }
+            .mapError { $0 as Error }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -221,9 +221,10 @@ final class EditClipReactor: Reactor {
                 .catchAndReturn(.updateIsSuccessedEditClip(false))
             }
         case .fetchFolder:
-            guard let clip = currentState.clip else { return .empty() }
+            guard let clip = currentState.clip,
+                  let folderID = clip.folderID else { return .empty() }
             return .fromAsync {
-                try await self.fetchFolderUseCase.execute(id: clip.folderID).get()
+                try await self.fetchFolderUseCase.execute(id: folderID).get()
             }
             .map { .updateCurrentFolder($0) }
             .catchAndReturn(.updateCurrentFolder(nil))


### PR DESCRIPTION
## 📌 관련 이슈

close #495
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- Clip 엔티티의 `folderID`를 옵셔널 타입으로 변경(옵셔널이면 TopLevel 클립이라는 뜻입니다)
- ClipStorage, ClipRepository, ClipUseCase에 `fetchTopLevelClips` 로직 구현
- insert, update 조건에서 folder nil check 로직 제거
- 위 변경 사항에 따른 빌드 오류 수정

## 📌 참고 사항

- UI 구현은 미포함입니다.
- 빌드 오류는 수정되었으나, 논리적인 오류가 모두 수정된 상태는 아닙니다. (각 화면 담당자들한테 전달 완료 ✅)
