### PR TITLE
FA버튼 구현

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/Button/AddFAButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Button/AddFAButton.swift
@@ -1,0 +1,73 @@
+import UIKit
+
+final class AddFAButton: UIButton {
+    private let innerButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .blue600
+        button.setImage(.plus.withTintColor(.white900), for: .normal)
+        button.layer.cornerRadius = 24
+        button.layer.shadowColor = UIColor.black.cgColor
+        button.layer.shadowOpacity = 0.15
+        button.layer.shadowRadius = 8
+        button.layer.masksToBounds = false
+        return button
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+extension AddFAButton {
+    override func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        willDisplayMenuFor configuration: UIContextMenuConfiguration,
+        animator: UIContextMenuInteractionAnimating?
+    ) {
+        animator?.addAnimations {
+            self.innerButton.transform = CGAffineTransform(rotationAngle: .pi / 4) // 45도 회전
+        }
+    }
+
+    override func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        willEndFor configuration: UIContextMenuConfiguration,
+        animator: UIContextMenuInteractionAnimating?
+    ) {
+        animator?.addAnimations {
+            self.innerButton.transform = .identity
+        }
+    }
+}
+
+private extension AddFAButton {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setAttributes() {
+        backgroundColor = .clear
+    }
+
+    func setHierarchy() {
+        addSubview(innerButton)
+    }
+
+    func setConstraints() {
+        self.snp.makeConstraints { make in
+            make.size.equalTo(60)
+        }
+
+        innerButton.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.size.equalTo(48)
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/Common/Button/AddFAButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Button/AddFAButton.swift
@@ -21,6 +21,16 @@ final class AddFAButton: UIButton {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let path = UIBezierPath(
+            roundedRect: innerButton.bounds,
+            cornerRadius: innerButton.layer.cornerRadius
+        )
+        innerButton.layer.shadowPath = path.cgPath
+    }
 }
 
 extension AddFAButton {

--- a/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
@@ -48,7 +48,13 @@ final class FolderView: UIView {
 
     private let navigationView = CommonNavigationView()
     private let backButton = BackButton()
-    private let addButton = AddButton()
+
+    private lazy var addButton: AddFAButton = {
+        let button = AddFAButton()
+        button.showsMenuAsPrimaryAction = true
+        button.menu = makeAddButtonMenu()
+        return button
+    }()
 
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(
@@ -294,7 +300,6 @@ private extension FolderView {
 
     func setAttributes() {
         navigationView.setLeftItem(backButton)
-        navigationView.setRightItem(addButton)
 
         addButton.menu = makeAddButtonMenu()
         addButton.showsMenuAsPrimaryAction = true
@@ -303,7 +308,7 @@ private extension FolderView {
     }
 
     func setHierarchy() {
-        [navigationView, collectionView, emptyView, emptyAddButton, activityIndicator].forEach {
+        [navigationView, collectionView, emptyView, emptyAddButton, activityIndicator, addButton].forEach {
             addSubview($0)
         }
     }
@@ -319,7 +324,8 @@ private extension FolderView {
         }
 
         addButton.snp.makeConstraints { make in
-            make.size.equalTo(48)
+            make.trailing.equalToSuperview().inset(18)
+            make.bottom.equalToSuperview().inset(28)
         }
 
         collectionView.snp.makeConstraints { make in

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -66,8 +66,8 @@ final class HomeView: UIView {
         return label
     }()
 
-    private lazy var addButton: AddButton = {
-        let button = AddButton()
+    private lazy var addButton: AddFAButton = {
+        let button = AddFAButton()
         button.showsMenuAsPrimaryAction = true
         button.menu = makeAddButtonMenu()
         return button
@@ -416,12 +416,12 @@ private extension HomeView {
             collectionView,
             emptyView,
             emptyAddButton,
-            loadingIndicator
+            loadingIndicator,
+            addButton
         ].forEach { addSubview($0) }
 
         [
-            titleLabel,
-            addButton
+            titleLabel
         ].forEach { navigationView.addSubview($0) }
     }
 
@@ -438,9 +438,8 @@ private extension HomeView {
         }
 
         addButton.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().inset(24)
-            make.centerY.equalToSuperview()
-            make.size.equalTo(48)
+            make.trailing.equalToSuperview().inset(18)
+            make.bottom.equalToSuperview().inset(28)
         }
 
         collectionView.snp.makeConstraints { make in


### PR DESCRIPTION
## 📌 관련 이슈
close #519 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- FA버튼 구현 및 기존 버튼 변경

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/8c5e6a6d-9b5a-4dd9-b889-9807ca6db1b9" width="250px"> |

## 📌 참고 사항
-  UIMenu의 간격을 조금 주기 위해서 AddFAButton은 컨테이너의 역할을 합니다.
