### PR TITLE
다른 모든 앱에서 공유하기 버튼으로 담담 보이도록 수정

### DIFF
--- a/Clipster/Clipster/App/Derived/Info.plist
+++ b/Clipster/Clipster/App/Derived/Info.plist
@@ -73,5 +73,10 @@
 		<key>UIColorName</key>
 		<string>LaunchScreenBackgroundColor</string>
 	</dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 </dict>
 </plist>

--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -30,7 +30,7 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
 
     func resolveRedirectURL(initialURL: URL) async -> URL {
         var request = URLRequest(url: initialURL)
-        request.httpMethod = "HEAD"
+        request.httpMethod = "get"
 
         do {
             let (_, response) = try await URLSession.shared.data(for: request)

--- a/Clipster/Clipster/Domain/UseCase/URL/DefaultParseURLUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/URL/DefaultParseURLUseCase.swift
@@ -68,7 +68,7 @@ private extension DefaultParseURLUseCase {
 
         var thumbnailImageURL: String?
 
-        if let host = url.host(percentEncoded: false), host.contains("youtube") {
+        if let host = url.host(percentEncoded: false), host.contains("youtu") {
             if let videoID = extractYouTubeVideoID(from: url) {
                 thumbnailImageURL = "https://img.youtube.com/vi/\(videoID)/hqdefault.jpg"
             }

--- a/Clipster/Clipster/Domain/UseCase/URL/DefaultParseURLUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/URL/DefaultParseURLUseCase.swift
@@ -14,14 +14,17 @@ final class DefaultParseURLUseCase: ParseURLUseCase {
 
         let resolveFinalURL = await urlRepository.resolveRedirectURL(initialURL: sanitizeURL)
 
-        guard let html = try? await urlRepository.fetchHTML(from: resolveFinalURL).get() else {
-            return .failure(.unknown)
+        let htmlResult = await urlRepository.fetchHTML(from: resolveFinalURL)
+
+        switch htmlResult {
+        case .success(let html):
+            let screenshotData = await urlRepository.captureScreenshot(rect: nil)
+            let parsedMetadata = createParsedURLMetadata(url: sanitizeURL, html: html, screenshotData: screenshotData)
+            return .success((parsedMetadata, true))
+
+        case .failure(let error):
+            return .failure(error)
         }
-
-        let screenshotData = await urlRepository.captureScreenshot(rect: nil)
-        let parsedMetadata = createParsedURLMetadata(url: sanitizeURL, html: html, screenshotData: screenshotData)
-
-        return .success((parsedMetadata, true))
     }
 }
 

--- a/Clipster/ShareExtension/Info.plist
+++ b/Clipster/ShareExtension/Info.plist
@@ -6,13 +6,8 @@
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
-			<key>NSExtensionActivationRule</key>
-			<dict>
-				<key>NSExtensionActivationSupportsText</key>
-				<true/>
-				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>1</integer>
-			</dict>
+            <key>NSExtensionActivationRule</key>
+            <string>TRUEPREDICATE</string>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.share-services</string>


### PR DESCRIPTION
## 📌 관련 이슈

close #451 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- ATS 허용 - 원티드 앱에서 공고 공유 시 http:// URL 형식
- Share Extension URL 파싱 로직 수정
- 다양한 앱에서 공유 시 담담 앱 보이도록 수정

## 📌 참고 사항
- 유튜브 앱, 깃허브 앱, 네이버 앱(검색 이후 공유 버튼), 네이버 카페 앱, 원티드 앱, 알바천국 앱에서 공유 버튼 클릭 시 담담 확인 했습니다.

- URL 메타데이터 추출 시 앱스토어는 현재 추출할 수 없습니다. URL 메타데이터 추출을 WKWebView로 진행하고 있는데, 보안상의 이유로 애플이 제공하는 앱의 대부분은 WKWebView로 접근하지 못 한다고 하네요. (저장 이후 웹 뷰로 이동은 됨)
- WKWebView를 사용하는 이유가 스크린 샷 때문인데 추후에 애플 관련 URL은 URLSession이나 Apple Search API 같은걸로 파싱해야겠네요.

- 타 앱에서 안 보이는 경우 제보 받습니다.

