### PR TITLE
홈 클립 삭제 후 Reload 및 섹션 헤더 재사용 Hidden 처리

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/Cell/CollectionHeaderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Cell/CollectionHeaderView.swift
@@ -29,6 +29,11 @@ final class CollectionHeaderView: UICollectionReusableView {
         configure()
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        showAllButton.isHidden = true
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Clipster/Clipster/Presentation/Scene/Home/Reactor/HomeReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Reactor/HomeReactor.swift
@@ -121,7 +121,12 @@ final class HomeReactor: Reactor {
 
                     async let unvisitedClipsResult = fetchUnvisitedClipsUseCase.execute().get()
                     async let foldersResult = fetchTopLevelFoldersUseCase.execute().get()
-                    let (unvisitedClips, folders) = try await (unvisitedClipsResult, foldersResult)
+                    async let clipsResult = fetchTopLevelClipsUseCase.execute().get()
+                    let (unvisitedClips, folders, clips) = try await (
+                        unvisitedClipsResult,
+                        foldersResult,
+                        clipsResult
+                    )
 
                     return .setHomeDisplay(unvisitedClips, folders, clips)
                 },


### PR DESCRIPTION
## 📌 관련 이슈
close #535 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 클립 삭제 후 Reload
- 섹션 헤더 재사용시 Hidden 처리