### PR TITLE
In-memory 캐시 초기 구현

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -4,14 +4,17 @@ import Foundation
 final class DIContainer {
     private let container: NSPersistentContainer
     private let supabaseService: SupabaseService
+    private let cache: FolderClipCache
 
     init(
         container: NSPersistentContainer? = nil,
         supabaseURL: URL,
         supabaseKey: String,
+        cache: FolderClipCache,
     ) {
         self.container = container ?? CoreDataStack.shared.container
         supabaseService = SupabaseService(url: supabaseURL, key: supabaseKey)
+        self.cache = cache
     }
 
     func makeClipStorage() -> ClipStorage {
@@ -31,11 +34,11 @@ final class DIContainer {
     }
 
     func makeClipRepository() -> ClipRepository {
-        DefaultClipRepository(storage: makeClipStorage())
+        DefaultClipRepository(storage: makeClipStorage(), cache: cache)
     }
 
     func makeFolderRepository() -> FolderRepository {
-        DefaultFolderRepository(storage: makeFolderStorage())
+        DefaultFolderRepository(storage: makeFolderStorage(), cache: cache)
     }
 
     func makeURLMetadataRepository() -> DefaultURLRepository {

--- a/Clipster/Clipster/App/Source/SceneDelegate.swift
+++ b/Clipster/Clipster/App/Source/SceneDelegate.swift
@@ -30,9 +30,14 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         let supabaseURLString = Bundle.main.infoDictionary?["SUPABASE_URL"] as? String ?? ""
         let supabaseKey = Bundle.main.infoDictionary?["SUPABASE_KEY"] as? String ?? ""
+        let cache = FolderClipCache()
 
         if let supabaseURL = URL(string: supabaseURLString) {
-            let diContainer = DIContainer(supabaseURL: supabaseURL, supabaseKey: supabaseKey)
+            let diContainer = DIContainer(
+                supabaseURL: supabaseURL,
+                supabaseKey: supabaseKey,
+                cache: cache,
+            )
 
             appCoordinator = AppCoordinator(
                 navigationController: navigationController,

--- a/Clipster/Clipster/Data/Model/Cache/FolderClipCache.swift
+++ b/Clipster/Clipster/Data/Model/Cache/FolderClipCache.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+actor FolderClipCache {
+    private var folderCache = [UUID: Folder]()
+    private var clipCache = [UUID: Clip]()
+
+    func folders() -> [Folder] {
+        Array(folderCache.values)
+    }
+
+    func folder(by id: UUID) -> Folder? {
+        folderCache[id]
+    }
+
+    func setFolder(_ folder: Folder) {
+        folderCache[folder.id] = folder
+    }
+
+    func resetAndSetFolders(_ folders: [Folder]) {
+        folderCache = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
+    }
+
+    func clips() -> [Clip] {
+        Array(clipCache.values)
+    }
+
+    func clip(by id: UUID) -> Clip? {
+        clipCache[id]
+    }
+
+    func setClip(_ clip: Clip) {
+        clipCache[clip.id] = clip
+    }
+
+    func resetAndSetClips(_ clips: [Clip]) {
+        clipCache = Dictionary(uniqueKeysWithValues: clips.map { ($0.id, $0) })
+    }
+}

--- a/Clipster/Clipster/Data/Model/Cache/FolderClipCache.swift
+++ b/Clipster/Clipster/Data/Model/Cache/FolderClipCache.swift
@@ -4,6 +4,13 @@ actor FolderClipCache {
     private var folderCache = [UUID: Folder]()
     private var clipCache = [UUID: Clip]()
 
+    var isFoldersInitialized = false
+    var isClipsInitialized = false
+
+    var isInitialized: Bool {
+        isFoldersInitialized && isClipsInitialized
+    }
+
     func folders() -> [Folder] {
         Array(folderCache.values)
     }
@@ -18,6 +25,7 @@ actor FolderClipCache {
 
     func resetAndSetFolders(_ folders: [Folder]) {
         folderCache = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
+        isFoldersInitialized = true
     }
 
     func clips() -> [Clip] {
@@ -34,5 +42,13 @@ actor FolderClipCache {
 
     func resetAndSetClips(_ clips: [Clip]) {
         clipCache = Dictionary(uniqueKeysWithValues: clips.map { ($0.id, $0) })
+        isClipsInitialized = true
+    }
+
+    func reset() {
+        folderCache.removeAll()
+        clipCache.removeAll()
+        isFoldersInitialized = false
+        isClipsInitialized = false
     }
 }

--- a/Clipster/Clipster/Data/Repository/Clip/DefaultClipRepository.swift
+++ b/Clipster/Clipster/Data/Repository/Clip/DefaultClipRepository.swift
@@ -2,9 +2,11 @@ import Foundation
 
 final class DefaultClipRepository: ClipRepository {
     private let storage: ClipStorage
+    private let cache: FolderClipCache
 
-    init(storage: ClipStorage) {
+    init(storage: ClipStorage, cache: FolderClipCache) {
         self.storage = storage
+        self.cache = cache
     }
 
     func fetchClip(by id: UUID) async -> Result<Clip, DomainError> {

--- a/Clipster/Clipster/Data/Repository/Clip/DefaultClipRepository.swift
+++ b/Clipster/Clipster/Data/Repository/Clip/DefaultClipRepository.swift
@@ -10,32 +10,80 @@ final class DefaultClipRepository: ClipRepository {
     }
 
     func fetchClip(by id: UUID) async -> Result<Clip, DomainError> {
-        await storage.fetchClip(by: id)
-            .mapError { _ in .unknownError }
+        if await cache.isClipsInitialized {
+            guard let clip = await cache.clip(by: id) else {
+                return .failure(.entityNotFound)
+            }
+            return .success(clip)
+        } else {
+            return await storage.fetchClip(by: id)
+                .mapError { _ in .fetchFailed }
+        }
     }
 
     func fetchTopLevelClips() async -> Result<[Clip], DomainError> {
-        await storage.fetchTopLevelClips()
-            .mapError { _ in .unknownError }
+        if await cache.isClipsInitialized {
+            let clips = await cache.clips()
+            return .success(clips.filter {
+                $0.folderID == nil && $0.deletedAt == nil
+            })
+        } else {
+            return await storage.fetchTopLevelClips()
+                .mapError { _ in .fetchFailed }
+        }
     }
 
     func fetchUnvisitedClips() async -> Result<[Clip], DomainError> {
-        await storage.fetchUnvisitedClips()
-            .mapError { _ in .unknownError }
+        if await cache.isClipsInitialized {
+            let clips = await cache.clips()
+            return .success(clips.filter {
+                $0.lastVisitedAt == nil && $0.deletedAt == nil
+            })
+        } else {
+            return await storage.fetchUnvisitedClips()
+                .mapError { _ in .fetchFailed }
+        }
     }
 
-    func createClip(_ clip: Clip) async -> Result<Void, DomainError> {
-        await storage.insertClip(clip)
-            .mapError { _ in .unknownError }
+    func insertClip(_ clip: Clip) async -> Result<Void, DomainError> {
+        let result = await storage.insertClip(clip)
+
+        switch result {
+        case .success:
+            if await cache.isClipsInitialized {
+                await cache.setClip(clip)
+            }
+            return .success(())
+        case .failure:
+            return .failure(.insertFailed)
+        }
     }
 
     func updateClip(_ clip: Clip) async -> Result<Void, DomainError> {
-        await storage.updateClip(clip)
-            .mapError { _ in .unknownError }
+        let result = await storage.updateClip(clip)
+
+        switch result {
+        case .success:
+            if await cache.isClipsInitialized {
+                await cache.setClip(clip)
+            }
+            return .success(())
+        case .failure:
+            return .failure(.updateFailed)
+        }
     }
 
     func deleteClip(_ clip: Clip) async -> Result<Void, DomainError> {
-        await storage.deleteClip(clip)
-            .mapError { _ in .unknownError }
+        let result = await storage.deleteClip(clip)
+
+        switch result {
+        case .success:
+            if await cache.isClipsInitialized {
+                await cache.setClip(clip)
+            }
+            return .success(())
+        case .failure:
+            return .failure(.deleteFailed)
+        }
     }
 }

--- a/Clipster/Clipster/Data/Repository/Folder/DefaultFolderRepository.swift
+++ b/Clipster/Clipster/Data/Repository/Folder/DefaultFolderRepository.swift
@@ -2,9 +2,11 @@ import Foundation
 
 final class DefaultFolderRepository: FolderRepository {
     private let storage: FolderStorage
+    private let cache: FolderClipCache
 
-    init(storage: FolderStorage) {
+    init(storage: FolderStorage, cache: FolderClipCache) {
         self.storage = storage
+        self.cache = cache
     }
 
     func fetchFolder(by id: UUID) async -> Result<Folder, DomainError> {

--- a/Clipster/Clipster/Data/Repository/Folder/DefaultFolderRepository.swift
+++ b/Clipster/Clipster/Data/Repository/Folder/DefaultFolderRepository.swift
@@ -10,27 +10,66 @@ final class DefaultFolderRepository: FolderRepository {
     }
 
     func fetchFolder(by id: UUID) async -> Result<Folder, DomainError> {
-        await storage.fetchFolder(by: id)
-            .mapError { _ in .unknownError }
+        if await cache.isFoldersInitialized {
+            guard let folder = await cache.folder(by: id) else {
+                return .failure(.entityNotFound)
+            }
+            return .success(folder)
+        } else {
+            return await storage.fetchFolder(by: id)
+                .mapError { _ in .fetchFailed }
+        }
     }
 
     func fetchTopLevelFolders() async -> Result<[Folder], DomainError> {
-        await storage.fetchTopLevelFolders()
-            .mapError { _ in .unknownError }
+        if await cache.isFoldersInitialized {
+            let folders = await cache.folders()
+            return .success(folders.filter { $0.parentFolderID == nil && $0.deletedAt == nil })
+        } else {
+            return await storage.fetchTopLevelFolders()
+                .mapError { _ in .fetchFailed }
+        }
     }
 
     func insertFolder(_ folder: Folder) async -> Result<Void, DomainError> {
-        await storage.insertFolder(folder)
-            .mapError { _ in .unknownError }
+        let result = await storage.insertFolder(folder)
+
+        switch result {
+        case .success:
+            if await cache.isFoldersInitialized {
+                await cache.setFolder(folder)
+            }
+            return .success(())
+        case .failure:
+            return .failure(.insertFailed)
+        }
     }
 
     func updateFolder(_ folder: Folder) async -> Result<Void, DomainError> {
-        await storage.updateFolder(folder)
-            .mapError { _ in .unknownError }
+        let result = await storage.updateFolder(folder)
+
+        switch result {
+        case .success:
+            if await cache.isFoldersInitialized {
+                await cache.setFolder(folder)
+            }
+            return .success(())
+        case .failure:
+            return .failure(.updateFailed)
+        }
     }
 
     func deleteFolder(_ folder: Folder) async -> Result<Void, DomainError> {
-        await storage.deleteFolder(folder)
-            .mapError { _ in .unknownError }
+        let result = await storage.deleteFolder(folder)
+
+        switch result {
+        case .success:
+            if await cache.isFoldersInitialized {
+                await cache.setFolder(folder)
+            }
+            return .success(())
+        case .failure:
+            return .failure(.deleteFailed)
+        }
     }
 }

--- a/Clipster/Clipster/Domain/Error/DomainError.swift
+++ b/Clipster/Clipster/Domain/Error/DomainError.swift
@@ -1,3 +1,8 @@
 enum DomainError: Error {
     case unknownError
+    case entityNotFound
+    case fetchFailed
+    case insertFailed
+    case updateFailed
+    case deleteFailed
 }

--- a/Clipster/Clipster/Domain/Protocol/Repository/Clip/ClipRepository.swift
+++ b/Clipster/Clipster/Domain/Protocol/Repository/Clip/ClipRepository.swift
@@ -4,7 +4,7 @@ protocol ClipRepository {
     func fetchClip(by id: UUID) async -> Result<Clip, DomainError>
     func fetchTopLevelClips() async -> Result<[Clip], DomainError>
     func fetchUnvisitedClips() async -> Result<[Clip], DomainError>
-    func createClip(_ clip: Clip) async -> Result<Void, DomainError>
+    func insertClip(_ clip: Clip) async -> Result<Void, DomainError>
     func updateClip(_ clip: Clip) async -> Result<Void, DomainError>
     func deleteClip(_ clip: Clip) async -> Result<Void, DomainError>
 }

--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultCreateClipUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultCreateClipUseCase.swift
@@ -8,6 +8,6 @@ final class DefaultCreateClipUseCase: CreateClipUseCase {
     }
 
     func execute(_ clip: Clip) async -> Result<Void, Error> {
-        await clipRepository.createClip(clip).mapError { $0 as Error }
+        await clipRepository.insertClip(clip).mapError { $0 as Error }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

close #492 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- In-memory 캐시 초기 구현

## 📌 참고 사항

LaunchScreen 직후 모든 데이터를 Fetch한 뒤, `isInitialized` 플래그를 true로 만드는 호출이 있어야 인메모리 캐싱이 본격적으로 의미를 갖는데, 아직 Launch 로직이 구현되어 있지 않습니다. 따라서 이 PR이 머지가 되더라도 캐싱이 되진 않으니 파일 구조와 로직의 구현 방식 위주로 봐주시면 감사하겠습니다 🙏
`FolderClipCache`라는 이름이 조금 아쉬운데, 더 나은 의견이 있다면 수정하겠습니다.
