### PR TITLE
테마 선택 모달 구현

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -395,7 +395,8 @@ final class DIContainer {
             fetchClipSortUseCase: makeFetchClipSortUseCase(),
             fetchSavePathLayoutUseCase: makeFetchSavePathLayoutUseCase(),
             logoutUseCase: makeLogoutUseCase(),
-            withdrawUseCase: makeWithdrawUseCase()
+            withdrawUseCase: makeWithdrawUseCase(),
+            saveThemeOptionUseCase: makeSaveThemeUseCase()
         )
     }
 }

--- a/Clipster/Clipster/Presentation/Coordinator/MyPage/MyPageCoordinator.swift
+++ b/Clipster/Clipster/Presentation/Coordinator/MyPage/MyPageCoordinator.swift
@@ -25,6 +25,26 @@ extension MyPageCoordinator {
         navigationController.pushViewController(vc, animated: true)
     }
 
+    func showSelectTheme(
+        current: ThemeOption,
+        options: [ThemeOption],
+        onSelect: @escaping (ThemeOption) -> Void
+    ) {
+        let vc = SingleOptionSelectorViewController<ThemeOption>(
+            title: "테마",
+            options: options,
+            selected: current,
+            onSelect: onSelect
+        )
+
+        vc.modalPresentationStyle = .pageSheet
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.custom { $0.maximumDetentValue * 0.4 }]
+        }
+
+        navigationController.present(vc, animated: true)
+    }
+
     func showAppSettings() {
         guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
         UIApplication.shared.open(url)

--- a/Clipster/Clipster/Presentation/Protocol/SelectableOption.swift
+++ b/Clipster/Clipster/Presentation/Protocol/SelectableOption.swift
@@ -1,0 +1,3 @@
+protocol SelectableOption: Hashable {
+    var displayText: String { get }
+}

--- a/Clipster/Clipster/Presentation/Resource/Icon.xcassets/RadioSelected.imageset/Contents.json
+++ b/Clipster/Clipster/Presentation/Resource/Icon.xcassets/RadioSelected.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "RadioSelected.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Clipster/Clipster/Presentation/Resource/Icon.xcassets/RadioSelected.imageset/RadioSelected.svg
+++ b/Clipster/Clipster/Presentation/Resource/Icon.xcassets/RadioSelected.imageset/RadioSelected.svg
@@ -1,0 +1,5 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="14.75" y="14.75" width="18.5" height="18.5" rx="9.25" fill="#0066FF"/>
+<rect x="14.75" y="14.75" width="18.5" height="18.5" rx="9.25" stroke="#0066FF" stroke-width="1.5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M28 24C28 26.208 26.208 28 24 28C21.792 28 20 26.208 20 24C20 21.792 21.792 20 24 20C26.208 20 28 21.792 28 24Z" fill="white"/>
+</svg>

--- a/Clipster/Clipster/Presentation/Resource/Icon.xcassets/RadioUnselected.imageset/Contents.json
+++ b/Clipster/Clipster/Presentation/Resource/Icon.xcassets/RadioUnselected.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "RadioUnselected.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Clipster/Clipster/Presentation/Resource/Icon.xcassets/RadioUnselected.imageset/RadioUnselected.svg
+++ b/Clipster/Clipster/Presentation/Resource/Icon.xcassets/RadioUnselected.imageset/RadioUnselected.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="14.75" y="14.75" width="18.5" height="18.5" rx="9.25" stroke="#70737C" stroke-opacity="0.22" stroke-width="1.5"/>
+</svg>

--- a/Clipster/Clipster/Presentation/Scene/Common/Cell/RadioCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Cell/RadioCell.swift
@@ -1,0 +1,64 @@
+import SnapKit
+import UIKit
+
+final class RadioCell: UITableViewCell {
+    private let radioImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .radioUnselected
+        imageView.backgroundColor = .clear
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .black100
+        label.font = .pretendard(size: 16, weight: .regular)
+        return label
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setDisplay(text: String, isSelected: Bool) {
+        titleLabel.text = text
+        radioImageView.image = isSelected ? .radioSelected : .radioUnselected
+    }
+}
+
+private extension RadioCell {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setAttributes() {
+        contentView.backgroundColor = .white900
+    }
+
+    func setHierarchy() {
+        [
+            radioImageView,
+            titleLabel
+        ].forEach { contentView.addSubview($0) }
+    }
+
+    func setConstraints() {
+        radioImageView.snp.makeConstraints { make in
+            make.leading.equalToSuperview()
+            make.size.equalTo(48)
+            make.centerY.equalToSuperview()
+        }
+
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalTo(radioImageView.snp.trailing).offset(4)
+            make.centerY.equalToSuperview()
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/MyPage/Model/Detail/ThemeOption+Extension.swift
+++ b/Clipster/Clipster/Presentation/Scene/MyPage/Model/Detail/ThemeOption+Extension.swift
@@ -7,3 +7,5 @@ extension ThemeOption {
         }
     }
 }
+
+extension ThemeOption: SelectableOption { }

--- a/Clipster/Clipster/Presentation/Scene/MyPage/Reactor/MyPageReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/MyPage/Reactor/MyPageReactor.swift
@@ -130,10 +130,13 @@ final class MyPageReactor: Reactor {
         case .changeTheme(let option):
             return .fromAsync { [weak self] in
                 guard let self else { throw DomainError.unknownError }
-
+                _ = try await saveThemeOptionUseCase.execute(option).get()
                 let sectionModels = replacingThemeItem(with: option, in: currentState.sectionModel)
                 print(sectionModels)
                 return .setSectionModel(sectionModels)
+            }
+            .catch {
+                .just(.setPhase(.error($0.localizedDescription)))
             }
         }
     }

--- a/Clipster/Clipster/Presentation/Scene/MyPage/Reactor/MyPageReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/MyPage/Reactor/MyPageReactor.swift
@@ -5,6 +5,7 @@ final class MyPageReactor: Reactor {
     enum Action {
         case viewWillAppear
         case tapCell(MyPageItem)
+        case changeTheme(ThemeOption)
     }
 
     enum Mutation {
@@ -58,6 +59,7 @@ final class MyPageReactor: Reactor {
     private let fetchSavePathLayoutUseCase: FetchSavePathLayoutOptionUseCase
     private let logoutUseCase: LogoutUseCase
     private let withdrawUseCase: WithdrawUseCase
+    private let saveThemeOptionUseCase: SaveThemeOptionUseCase
 
     init(
         loginUseCase: LoginUseCase,
@@ -66,7 +68,8 @@ final class MyPageReactor: Reactor {
         fetchClipSortUseCase: FetchClipSortOptionUseCase,
         fetchSavePathLayoutUseCase: FetchSavePathLayoutOptionUseCase,
         logoutUseCase: LogoutUseCase,
-        withdrawUseCase: WithdrawUseCase
+        withdrawUseCase: WithdrawUseCase,
+        saveThemeOptionUseCase: SaveThemeOptionUseCase
     ) {
         self.loginUseCase = loginUseCase
         self.fetchThemeUseCase = fetchThemeUseCase
@@ -75,6 +78,7 @@ final class MyPageReactor: Reactor {
         self.fetchSavePathLayoutUseCase = fetchSavePathLayoutUseCase
         self.logoutUseCase = logoutUseCase
         self.withdrawUseCase = withdrawUseCase
+        self.saveThemeOptionUseCase = saveThemeOptionUseCase
     }
 
     func mutate(action: Action) -> Observable<Mutation> {
@@ -120,6 +124,11 @@ final class MyPageReactor: Reactor {
             default:
                 return .empty()
             }
+        case .changeTheme(let option):
+            Task {
+                _ = try await saveThemeOptionUseCase.execute(option).get()
+            }
+            return .empty()
         }
     }
 

--- a/Clipster/Clipster/Presentation/Scene/MyPage/Reactor/MyPageReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/MyPage/Reactor/MyPageReactor.swift
@@ -10,12 +10,14 @@ final class MyPageReactor: Reactor {
 
     enum Mutation {
         case setSectionModel([MyPageSectionModel])
+        case setIsScrollToTop(Bool)
         case setPhase(State.Phase)
         case setRoute(State.Route?)
     }
 
     struct State {
         var sectionModel: [MyPageSectionModel] = []
+        @Pulse var isScrollToTop: Bool = false
         @Pulse var phase: Phase = .idle
         @Pulse var route: Route?
 
@@ -116,6 +118,7 @@ final class MyPageReactor: Reactor {
                         guard let self else { throw DomainError.unknownError }
                         return try await makeAccountItemMutation(item: accountItem)
                     },
+                    .just(.setIsScrollToTop(true)),
                     .just(.setPhase(.success))
                 )
                 .catch {
@@ -140,6 +143,8 @@ final class MyPageReactor: Reactor {
         switch mutation {
         case .setSectionModel(let model):
             newState.sectionModel = model
+        case .setIsScrollToTop(let isScrollToTop):
+            newState.isScrollToTop = isScrollToTop
         case .setPhase(let phase):
             newState.phase = phase
         case .setRoute(let route):

--- a/Clipster/Clipster/Presentation/Scene/MyPage/ViewController/MyPageViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/MyPage/ViewController/MyPageViewController.swift
@@ -107,8 +107,13 @@ extension MyPageViewController {
                 switch route {
                 case .showEditNickName:
                     break
-                case .showSelectTheme:
-                    break
+                case .showSelectTheme(let currentOption, let availableOptions):
+                    coordinator?.showSelectTheme(
+                        current: currentOption,
+                        options: availableOptions
+                    ) { [weak self] selected in
+                        self?.reactor?.action.onNext(.changeTheme(selected))
+                    }
                 case .showSelectFolderSort:
                     break
                 case .showSelectClipSort:

--- a/Clipster/Clipster/Presentation/Scene/MyPage/ViewController/MyPageViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/MyPage/ViewController/MyPageViewController.swift
@@ -72,6 +72,15 @@ extension MyPageViewController {
                 guard let self else { return }
 
                 myPageView.setDisplay(sections)
+            }
+            .disposed(by: disposeBag)
+
+        reactor.pulse(\.$isScrollToTop)
+            .filter { $0 }
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] _ in
+                guard let self else { return }
+
                 myPageView.scrollToTop(animated: false)
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/SingleOptionSelector/ViewController/SingleOptionSelectorViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/SingleOptionSelector/ViewController/SingleOptionSelectorViewController.swift
@@ -1,0 +1,161 @@
+import RxRelay
+import RxSwift
+import SnapKit
+import UIKit
+
+final class SingleOptionSelectorViewController<Option: SelectableOption>: UIViewController {
+    typealias Section = Int
+    typealias Item = Option
+
+    let disposeBag = DisposeBag()
+
+    private let options: [Option]
+    private var selected: Option
+    private let onSelect: (Option) -> Void
+    private var dataSource: UITableViewDiffableDataSource<Section, Item>?
+
+    private let grabberView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .black50
+        view.layer.cornerRadius = 2.5
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .black100
+        label.font = .pretendard(size: 16, weight: .semiBold)
+        return label
+    }()
+
+    private let separatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .black800
+        return view
+    }()
+
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.separatorStyle = .none
+        tableView.rowHeight = 48
+        tableView.backgroundColor = .clear
+        tableView.register(RadioCell.self, forCellReuseIdentifier: RadioCell.identifier)
+        return tableView
+    }()
+
+    init(
+        title: String,
+        options: [Option],
+        selected: Option,
+        onSelect: @escaping (Option) -> Void
+    ) {
+        self.options = options
+        self.selected = selected
+        self.onSelect = onSelect
+        super.init(nibName: nil, bundle: nil)
+        titleLabel.text = title
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configure()
+        configureDataSource()
+        applySnapshot()
+    }
+
+    private func configureDataSource() {
+        dataSource = .init(tableView: tableView) { tableView, indexPath, item in
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: RadioCell.identifier,
+                for: indexPath
+            ) as? RadioCell else { return UITableViewCell() }
+
+            let isSelected = item == self.selected
+            cell.setDisplay(text: item.displayText, isSelected: isSelected)
+            return cell
+        }
+    }
+
+    private func applySnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Option>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(options)
+        dataSource?.apply(snapshot, animatingDifferences: false)
+    }
+
+    private func updateSelection(_ newSelected: Option) {
+        guard newSelected != selected else { return }
+
+        let oldSelected = selected
+        selected = newSelected
+        onSelect(newSelected)
+
+        guard var snapshot = dataSource?.snapshot() else { return }
+        snapshot.reconfigureItems([oldSelected, newSelected])
+        dataSource?.apply(snapshot, animatingDifferences: false)
+    }
+}
+
+private extension SingleOptionSelectorViewController {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+        setBindings()
+    }
+
+    func setAttributes() {
+        view.backgroundColor = .white900
+    }
+
+    func setHierarchy() {
+        [
+            grabberView,
+            titleLabel,
+            separatorView,
+            tableView
+        ].forEach { view.addSubview($0) }
+    }
+
+    func setConstraints() {
+        grabberView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(8)
+            make.width.equalTo(134)
+            make.height.equalTo(5)
+            make.centerX.equalToSuperview()
+        }
+
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(grabberView.snp.bottom).offset(8)
+            make.horizontalEdges.equalToSuperview().inset(24)
+            make.height.equalTo(48)
+        }
+
+        separatorView.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(1)
+        }
+
+        tableView.snp.makeConstraints { make in
+            make.top.equalTo(separatorView.snp.bottom)
+            make.horizontalEdges.equalToSuperview()
+            make.bottom.equalToSuperview()
+        }
+    }
+
+    func setBindings() {
+        tableView.rx.itemSelected
+            .bind { [weak self] indexPath in
+                guard let self,
+                      let selected = dataSource?.itemIdentifier(for: indexPath)
+                else { return }
+                self.updateSelection(selected)
+            }
+            .disposed(by: disposeBag)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

close #574 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 테마 선택 모달 추가
- 테마 변경마다 UI업데이트 및 UseCase 호출
- 로그아웃, 회원탈퇴시에만 ScrollToTop 되도록 변경

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/82a6616d-819b-45a4-824a-db226db48c1b" width="250px"> |

## 📌 PR Point
- 테마 변경 UI업데이트 할때 currentState에서 테마아이템을 직접 찾아서 변경하고있는데 좀 더 좋은 방법 있으면 피드백 부탁드릴게요