### PR TITLE
폴더 선택 후 상위 폴더를 접어도 타이틀에 선택된 폴더 이름이 보이도록 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/FolderSelector/Reactor/FolderSelectorReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/FolderSelector/Reactor/FolderSelectorReactor.swift
@@ -43,9 +43,24 @@ final class FolderSelectorReactor: Reactor {
 
         var title: String {
             if isAccordion {
-                if let folderID = highlightedFolderID,
-                   let highlightedFolder = displayableFolders.first(where: { $0.id == folderID }) {
-                    return highlightedFolder.title
+                if let highlightedID = self.highlightedFolderID {
+                    if highlightedID == Self.homeFolderID {
+                        return "홈"
+                    }
+
+                    func find(id: UUID, in folders: [Folder]) -> Folder? {
+                        for folder in folders {
+                            if folder.id == id { return folder }
+                            if let found = find(id: id, in: folder.folders) {
+                                return found
+                            }
+                        }
+                        return nil
+                    }
+
+                    if let foundFolder = find(id: highlightedID, in: self.topLevelFolders) {
+                        return foundFolder.title
+                    }
                 }
                 return "홈"
             } else {


### PR DESCRIPTION
## 📌 관련 이슈

close #585 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

폴더 선택화면에서 하위 폴더를 선택 후 상위 폴더를 접었을 때 타이틀이 '홈'으로 변경됨
폴더 선택 후 상위 폴더를 접어도 타이틀에 선택된 폴더 이름이 보이도록 수정

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/3ac9a852-c0c4-4302-8930-b60885cf80b4

https://github.com/user-attachments/assets/2b79e18d-a108-4829-9fe6-de375cadb84e
