### PR TITLE
EditClipView - Share Extension 관련 로직 제거

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -196,7 +196,6 @@ final class DIContainer {
         EditClipReactor(
             parseURLUseCase: makeParseURLUseCase(),
             fetchFolderUseCase: makeFetchFolderUseCase(),
-            fetchTopLevelFoldersUseCase: makeFetchTopLevelFoldersUseCase(),
             createClipUseCase: makeCreateClipUseCase(),
             updateClipUseCase: makeUpdateClipUseCase()
         )
@@ -207,7 +206,6 @@ final class DIContainer {
             urlText: urlString,
             parseURLUseCase: makeParseURLUseCase(),
             fetchFolderUseCase: makeFetchFolderUseCase(),
-            fetchTopLevelFoldersUseCase: makeFetchTopLevelFoldersUseCase(),
             createClipUseCase: makeCreateClipUseCase(),
             updateClipUseCase: makeUpdateClipUseCase()
         )
@@ -218,7 +216,6 @@ final class DIContainer {
             currentFolder: folder,
             parseURLUseCase: makeParseURLUseCase(),
             fetchFolderUseCase: makeFetchFolderUseCase(),
-            fetchTopLevelFoldersUseCase: makeFetchTopLevelFoldersUseCase(),
             createClipUseCase: makeCreateClipUseCase(),
             updateClipUseCase: makeUpdateClipUseCase()
         )
@@ -229,7 +226,6 @@ final class DIContainer {
             clip: clip,
             parseURLUseCase: makeParseURLUseCase(),
             fetchFolderUseCase: makeFetchFolderUseCase(),
-            fetchTopLevelFoldersUseCase: makeFetchTopLevelFoldersUseCase(),
             createClipUseCase: makeCreateClipUseCase(),
             updateClipUseCase: makeUpdateClipUseCase()
         )

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -172,14 +172,6 @@ extension EditClipViewController: View {
             .disposed(by: disposeBag)
 
         reactor.state
-            .map { $0.type == .shareExtension }
-            .filter { $0 }
-            .take(1)
-            .map { _ in Reactor.Action.fetchTopLevelFolder }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-
-        reactor.state
             .map(\.memoText)
             .take(1)
             .asDriver(onErrorJustReturn: "")


### PR DESCRIPTION
## 📌 관련 이슈

close #577
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 더이상 ShareExtension에서 메인 앱 진입하지 않기 때문에 EditClipView 내의 Share Extension에서 진입할 경우에 대한 로직 제거
