### PR TITLE
Search~UseCase 공백 제거한 문자열 사용하도록 수정

### DIFF
--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultSearchClipsUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultSearchClipsUseCase.swift
@@ -7,8 +7,8 @@ final class DefaultSearchClipsUseCase: SearchClipsUseCase {
 
         return clips.filter {
             $0.url.absoluteString.localizedCaseInsensitiveContains(trimmedQuery) ||
-            $0.title.localizedCaseInsensitiveContains(query) ||
-            $0.memo.localizedCaseInsensitiveContains(query)
+            $0.title.localizedCaseInsensitiveContains(trimmedQuery) ||
+            $0.memo.localizedCaseInsensitiveContains(trimmedQuery)
         }
     }
 }

--- a/Clipster/Clipster/Domain/UseCase/Folder/DefaultSearchFoldersUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Folder/DefaultSearchFoldersUseCase.swift
@@ -6,7 +6,7 @@ final class DefaultSearchFoldersUseCase: SearchFoldersUseCase {
         }
 
         return folders.filter {
-            $0.title.localizedCaseInsensitiveContains(query)
+            $0.title.localizedCaseInsensitiveContains(trimmedQuery)
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

close #608 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

Reactor에서 공백 제거한 문자열을 넘겨주고 있지만,
방어적 프로그래밍 차원에서 UseCase에서도 공백 제거한 문자열을 사용하도록 수정
