### PR TITLE
EditClipView 진입 시 클립보드 감지

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -29,7 +29,7 @@ final class EditClipReactor: Reactor {
         case updateCurrentFolder(Folder?)
         case updateIsSuccessedEditClip(Bool)
         case updateIsLoading(Bool)
-        case updateIsShowKeyboard(Bool)
+        case updateShouldReadPastedboardURL(Bool)
     }
 
     struct State {
@@ -50,7 +50,7 @@ final class EditClipReactor: Reactor {
         var isURLValid = false
         var isTappedFolderView: Bool = false
         var isSuccessedEditClip: Bool = false
-        var isShowKeyboard: Bool = false
+        var shouldReadPastedboardURL: Bool = false
     }
 
     var initialState: State
@@ -216,7 +216,7 @@ final class EditClipReactor: Reactor {
         case .disappearFolderSelectorView:
             return .just(.updateIsTappedFolderView(false))
         case .viewDidAppear:
-            return .just(.updateIsShowKeyboard(true))
+            return .just(.updateShouldReadPastedboardURL(true))
         }
     }
 
@@ -277,8 +277,8 @@ final class EditClipReactor: Reactor {
             newState.isHiddenURLValidationStackView = currentState.urlString.isEmpty
             newState.urlValidationImageResource = .none
             newState.isHiddenURLValidationStackView = false
-        case .updateIsShowKeyboard(let value):
-            newState.isShowKeyboard = value
+        case .updateShouldReadPastedboardURL(let value):
+            newState.shouldReadPastedboardURL = value
         }
         return newState
     }


### PR DESCRIPTION
## 📌 관련 이슈

close #612
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- EditClipView 진입 시 클립보드 URL을 감지합니다.

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) | 비고 |
| :-------------: | :----------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/dcdcd3ef-80b5-4d7e-8925-805630272a33" width="250px"> | 클립보드 복사 동의 |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/a37834fc-80ea-42da-b343-07a7cd6c73ab" width="250px"> | 클립보드 복사 거절 |

## 📌 참고 사항

동의 또는 거절을 누른 이후 EditClipView 진입 시에는 클립보드 복사 감지 안 됩니다.(키보드 올라옴)
