### PR TITLE
FolderView 폴더, 클립 정렬 적용

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -213,11 +213,11 @@ final class DIContainer {
         DefaultSaveRecentQueryUseCase(userDefaults: userDefaults)
     }
 
-    func makeFetchClipSortUseCase() -> FetchClipSortOptionUseCase {
+    func makeFetchClipSortOptionUseCase() -> FetchClipSortOptionUseCase {
         DefaultFetchClipSortOptionUseCase(userDefaults: userDefaults)
     }
 
-    func makeFetchFolderSortUseCase() -> FetchFolderSortOptionUseCase {
+    func makeFetchFolderSortOptionUseCase() -> FetchFolderSortOptionUseCase {
         DefaultFetchFolderSortOptionUseCase(userDefaults: userDefaults)
     }
 
@@ -320,8 +320,8 @@ final class DIContainer {
         FolderReactor(
             folder: folder,
             fetchFolderUseCase: makeFetchFolderUseCase(),
-            fetchFolderSortOptionUseCase: makeFetchFolderSortUseCase(),
-            fetchClipSortOptionUseCase: makeFetchClipSortUseCase(),
+            fetchFolderSortOptionUseCase: makeFetchFolderSortOptionUseCase(),
+            fetchClipSortOptionUseCase: makeFetchClipSortOptionUseCase(),
             sortFoldersUseCase: makeSortFoldersUseCase(),
             sortClipsUseCase: makeSortClipsUseCase(),
             deleteFolderUseCase: makeDeleteFolderUseCase(),
@@ -395,8 +395,8 @@ final class DIContainer {
         MyPageReactor(
             loginUseCase: makeLoginUseCase(),
             fetchThemeUseCase: makeFetchThemeUseCase(),
-            fetchFolderSortUseCase: makeFetchFolderSortUseCase(),
-            fetchClipSortUseCase: makeFetchClipSortUseCase(),
+            fetchFolderSortUseCase: makeFetchFolderSortOptionUseCase(),
+            fetchClipSortUseCase: makeFetchClipSortOptionUseCase(),
             fetchSavePathLayoutUseCase: makeFetchSavePathLayoutUseCase(),
             logoutUseCase: makeLogoutUseCase(),
             withdrawUseCase: makeWithdrawUseCase()

--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -320,6 +320,10 @@ final class DIContainer {
         FolderReactor(
             folder: folder,
             fetchFolderUseCase: makeFetchFolderUseCase(),
+            fetchFolderSortOptionUseCase: makeFetchFolderSortUseCase(),
+            fetchClipSortOptionUseCase: makeFetchClipSortUseCase(),
+            sortFoldersUseCase: makeSortFoldersUseCase(),
+            sortClipsUseCase: makeSortClipsUseCase(),
             deleteFolderUseCase: makeDeleteFolderUseCase(),
             visitClipUseCase: makeVisitClipUseCase(),
             deleteClipUseCase: makeDeleteClipUseCase(),

--- a/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
@@ -13,7 +13,7 @@ final class FolderReactor: Reactor {
     }
 
     enum Mutation {
-        case reloadFolder(Folder)
+        case fetchFolder(Folder)
         case setPhase(Phase)
         case setRoute(Route)
     }
@@ -98,7 +98,7 @@ final class FolderReactor: Reactor {
         case .viewWillAppear:
             return .concat(
                 .just(.setPhase(.loading)),
-                reloadFolderMutation(),
+                fetchFolderMutation(),
                 .just(.setPhase(.success)),
             )
         case .didTapCell(let indexPath):
@@ -143,7 +143,7 @@ final class FolderReactor: Reactor {
             return .concat(
                 .just(.setPhase(.loading)),
                 deleteMutation(at: indexPath),
-                reloadFolderMutation(),
+                fetchFolderMutation(),
             )
         }
     }
@@ -152,7 +152,7 @@ final class FolderReactor: Reactor {
         var newState = state
 
         switch mutation {
-        case .reloadFolder(let folder):
+        case .fetchFolder(let folder):
             self.folder = folder
             newState.currentFolderTitle = folder.title
             newState.folders = folder.folders.map(FolderDisplayMapper.map)
@@ -169,7 +169,7 @@ final class FolderReactor: Reactor {
 }
 
 private extension FolderReactor {
-    func reloadFolderMutation() -> Observable<Mutation> {
+    func fetchFolderMutation() -> Observable<Mutation> {
         .fromAsync { [weak self] in
             guard let self else {
                 let message = DomainError.unknownError.localizedDescription
@@ -189,7 +189,7 @@ private extension FolderReactor {
                 updatedAt: folder.updatedAt,
                 deletedAt: folder.deletedAt,
             )
-            return .reloadFolder(sortedFolder)
+            return .fetchFolder(sortedFolder)
         }
         .catch { error in
             .just(.setPhase(.error(error.localizedDescription)))

--- a/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Reactor/FolderReactor.swift
@@ -51,7 +51,6 @@ final class FolderReactor: Reactor {
 
     let initialState: State
     private var folder: Folder
-    private var isFirstAppear = true
 
     private let fetchFolderUseCase: FetchFolderUseCase
     private let fetchFolderSortOptionUseCase: FetchFolderSortOptionUseCase
@@ -84,10 +83,10 @@ final class FolderReactor: Reactor {
         self.deleteClipUseCase = deleteClipUseCase
 
         initialState = State(
-            currentFolderTitle: folder.title,
-            folders: folder.folders.map { FolderDisplayMapper.map($0) },
-            clips: folder.clips.map { ClipDisplayMapper.map($0) },
-            isEmptyViewHidden: !folder.folders.isEmpty || !folder.clips.isEmpty,
+            currentFolderTitle: "",
+            folders: [],
+            clips: [],
+            isEmptyViewHidden: true,
             phase: .idle,
         )
     }
@@ -97,10 +96,6 @@ final class FolderReactor: Reactor {
 
         switch action {
         case .viewWillAppear:
-            if isFirstAppear {
-                isFirstAppear = false
-                return .empty()
-            }
             return .concat(
                 .just(.setPhase(.loading)),
                 reloadFolderMutation(),


### PR DESCRIPTION
## 📌 관련 이슈

close #623 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- FolderView 폴더, 클립 정렬 적용
- make 메서드 네이밍 수정

## 📌 참고 사항

- make 메서드 네이밍 수정이 반영되면, 아마 DIContainer에서 HomeReactor를 초기화하는 과정에서 빌드 오류가 생길 것 같습니다. (어떤게 먼저 merge 될지 아직 모르겠어서요 참고해주세요!)
