### PR TITLE
공통 네비게이션 뷰 레이아웃 경고 해결

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/View/CommonNavigationView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/View/CommonNavigationView.swift
@@ -14,6 +14,7 @@ final class CommonNavigationView: UIView {
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.distribution = .equalSpacing
+        stackView.isHidden = true
         stackView.setContentCompressionResistancePriority(.required, for: .horizontal)
         return stackView
     }()
@@ -23,6 +24,7 @@ final class CommonNavigationView: UIView {
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.distribution = .equalSpacing
+        stackView.isHidden = true
         stackView.setContentCompressionResistancePriority(.required, for: .horizontal)
         return stackView
     }()
@@ -47,6 +49,7 @@ final class CommonNavigationView: UIView {
     func setLeftItem(_ item: UIButton) {
         clearStackView(leftStackView)
         leftStackView.addArrangedSubview(item)
+        leftStackView.isHidden = false
     }
 
     func setLeftItems(_ items: [UIButton]) {
@@ -54,11 +57,13 @@ final class CommonNavigationView: UIView {
         items.forEach {
             leftStackView.addArrangedSubview($0)
         }
+        leftStackView.isHidden = false
     }
 
     func setRightItem(_ item: UIButton) {
         clearStackView(rightStackView)
         rightStackView.addArrangedSubview(item)
+        rightStackView.isHidden = false
     }
 
     func setRightItems(_ items: [UIButton]) {
@@ -66,6 +71,7 @@ final class CommonNavigationView: UIView {
         items.forEach {
             rightStackView.addArrangedSubview($0)
         }
+        rightStackView.isHidden = false
     }
 
     private func clearStackView(_ stackView: UIStackView) {
@@ -73,6 +79,7 @@ final class CommonNavigationView: UIView {
             stackView.removeArrangedSubview(view)
             view.removeFromSuperview()
         }
+        stackView.isHidden = true
     }
 }
 

--- a/Clipster/Clipster/Presentation/Scene/Common/View/CommonNavigationView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/View/CommonNavigationView.swift
@@ -99,12 +99,14 @@ private extension CommonNavigationView {
         leftStackView.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(24)
             make.trailing.lessThanOrEqualTo(titleLabel.snp.leading).offset(-26)
+            make.height.equalTo(48)
             make.centerY.equalToSuperview()
         }
 
         rightStackView.snp.makeConstraints { make in
             make.trailing.equalToSuperview().inset(24)
             make.leading.greaterThanOrEqualTo(titleLabel.snp.trailing).offset(26)
+            make.height.equalTo(48)
             make.centerY.equalToSuperview()
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈
close #632 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- Left/Right StackView의 alignment가 .center이기 때문에 내부에서 StackView의 높이를 정할 수 없음
-> 따라서 높이를 48로 지정하여 해결

- 스택뷰 비어있을경우 너비 모호함 문제 발생
-> 비어있을경우 hidden 처리

## 📌 PR Point
- 일단 문제 없는지 확인은 마쳤지만 혹시 모르니 맡으신 화면 View Hierarchy 확인 부탁드립니다