### PR TITLE
ShareExtension에서 메인 앱 진입 관련 로직 제거

### DIFF
--- a/Clipster/Clipster/App/Coordinator/App/AppCoordinator.swift
+++ b/Clipster/Clipster/App/Coordinator/App/AppCoordinator.swift
@@ -60,12 +60,4 @@ extension AppCoordinator {
         onboardingVC.modalPresentationStyle = .fullScreen
         navigationController.present(onboardingVC, animated: false)
     }
-
-    func handleSharedURL(_ urlString: String) {
-        if let homeCoordinator = children.compactMap({ $0 as? HomeCoordinator }).first {
-            homeCoordinator.showEditClipFromSharedURL(urlString: urlString)
-        } else {
-            print("HomeCoordinator가 아직 초기화되지 않았습니다.")
-        }
-    }
 }

--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -275,16 +275,6 @@ final class DIContainer {
         )
     }
 
-    func makeEditClipReactor(urlString: String) -> EditClipReactor {
-        EditClipReactor(
-            urlText: urlString,
-            parseURLUseCase: makeParseURLUseCase(),
-            fetchFolderUseCase: makeFetchFolderUseCase(),
-            createClipUseCase: makeCreateClipUseCase(),
-            updateClipUseCase: makeUpdateClipUseCase()
-        )
-    }
-
     func makeEditClipReactor(folder: Folder?) -> EditClipReactor {
         EditClipReactor(
             currentFolder: folder,

--- a/Clipster/Clipster/App/Source/SceneDelegate.swift
+++ b/Clipster/Clipster/App/Source/SceneDelegate.swift
@@ -55,14 +55,4 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             print("\(Self.self): ❌ Invalid Supabase URL")
         }
     }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        if let urlString = userDefaults.string(forKey: "sharedURL") {
-            userDefaults.removeObject(forKey: "sharedURL")
-
-            DispatchQueue.main.async {
-                self.appCoordinator?.handleSharedURL(urlString)
-            }
-        }
-    }
 }

--- a/Clipster/Clipster/Presentation/Coordinator/Home/HomeCoordinator.swift
+++ b/Clipster/Clipster/Presentation/Coordinator/Home/HomeCoordinator.swift
@@ -49,12 +49,6 @@ extension HomeCoordinator {
         navigationController.pushViewController(vc, animated: true)
     }
 
-    func showEditClipFromSharedURL(urlString: String) {
-        let reactor = diContainer.makeEditClipReactor(urlString: urlString)
-        let vc = EditClipViewController(reactor: reactor, coordinator: self)
-        navigationController.pushViewController(vc, animated: true)
-    }
-
     func showAddFolder(
         parentFolder: Folder? = nil,
         onComplete: ((Folder) -> Void)? = nil

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Reactor/EditClipReactor.swift
@@ -37,7 +37,7 @@ final class EditClipReactor: Reactor {
         var clip: Clip?
         var currentFolder: Folder?
         var navigationTitle: String
-        var urlString: String
+        var urlString: String = ""
         var memoText: String = ""
         var memoLimit: String = "0 / 100"
         var urlValidationImageResource: ImageResource?
@@ -61,7 +61,6 @@ final class EditClipReactor: Reactor {
     private let updateClipUseCase: UpdateClipUseCase
 
     init(
-        urlText: String = "",
         currentFolder: Folder? = nil,
         parseURLUseCase: ParseURLUseCase,
         fetchFolderUseCase: FetchFolderUseCase,
@@ -72,7 +71,6 @@ final class EditClipReactor: Reactor {
             type: .create,
             currentFolder: currentFolder,
             navigationTitle: "클립 추가",
-            urlString: urlText,
         )
         self.parseURLUseCase = parseURLUseCase
         self.fetchFolderUseCase = fetchFolderUseCase


### PR DESCRIPTION
## 📌 관련 이슈

close #659 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- Share Extension에서 바로 저장할 수 있는 기능이 구현되기 이전, 메인 앱 진입 -> EditClipView로 화면 전환될 때 관련 로직을 모두 제거하지 않았던 것 같습니다.
