### PR TITLE
MyPageReactor의 SectionModel 배열을 분리하여 각 상태별로 관리하도록 리팩토링

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/MyPage/Reactor/MyPageReactor.swift
+++ b/Clipster/Clipster/Presentation/Scene/MyPage/Reactor/MyPageReactor.swift
@@ -160,7 +160,8 @@ final class MyPageReactor: Reactor {
                         guard let self else { throw DomainError.unknownError }
                         _ = try await loginUseCase.execute(type: type).get()
                         return try await makeAllPreferencesMutation()
-                    }
+                    },
+                    .just(.setPhase(.success))
                 )
                 .catch {
                     .just(.setPhase(.error($0.localizedDescription)))

--- a/Clipster/Clipster/Presentation/Scene/MyPage/ViewController/MyPageViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/MyPage/ViewController/MyPageViewController.swift
@@ -55,7 +55,7 @@ extension MyPageViewController {
 
     func bindState(from reactor: Reactor) {
         reactor.state
-            .map { $0.sectionModel }
+            .map { $0.sectionModels }
             .distinctUntilChanged { lhs, rhs in
                 guard lhs.count == rhs.count else { return false }
 

--- a/Clipster/ClipsterTests/Presentation/Reactor/MyPageReactorTests.swift
+++ b/Clipster/ClipsterTests/Presentation/Reactor/MyPageReactorTests.swift
@@ -107,7 +107,7 @@ final class MyPageReactorTests: XCTestCase {
         XCTAssertTrue(fetchClipSortOptionUseCase.didCallExecute)
         XCTAssertTrue(fetchSavePathLayoutOptionUseCase.didCallExecute)
 
-        XCTAssertEqual(reactor.currentState.sectionModel, guestSectionModels)
+        XCTAssertEqual(reactor.currentState.sectionModels, guestSectionModels)
     }
 
     func test_로그인_탭() {
@@ -138,7 +138,7 @@ final class MyPageReactorTests: XCTestCase {
         XCTAssertTrue(fetchClipSortOptionUseCase.didCallExecute)
         XCTAssertTrue(fetchSavePathLayoutOptionUseCase.didCallExecute)
 
-        XCTAssertEqual(reactor.currentState.sectionModel, userSectionModels)
+        XCTAssertEqual(reactor.currentState.sectionModels, guestSectionModels)
     }
 
     func test_닉네임_변경_탭() {
@@ -161,7 +161,7 @@ final class MyPageReactorTests: XCTestCase {
 
         // then
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(routeResult, .showEditNickName(MockUser.someUser.nickname))
+        XCTAssertEqual(routeResult, .showEditNickName(""))
     }
 
     func test_알림설정_탭() {
@@ -357,7 +357,8 @@ final class MyPageReactorTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
         XCTAssertEqual(phaseResults, [.loading, .success])
         XCTAssertTrue(logoutUseCase.didCallExecute)
-        XCTAssertEqual(reactor.currentState.sectionModel, guestSectionModels)
+        XCTAssertEqual(reactor.currentState.sectionModels, guestSectionModels)
+        XCTAssertEqual(reactor.currentState.isScrollToTop, true)
     }
 
     func test_회원탈퇴_탭() {
@@ -382,13 +383,14 @@ final class MyPageReactorTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
         XCTAssertEqual(phaseResults, [.loading, .success])
         XCTAssertTrue(withdrawUseCase.didCallExecute)
-        XCTAssertEqual(reactor.currentState.sectionModel, guestSectionModels)
+        XCTAssertEqual(reactor.currentState.sectionModels, guestSectionModels)
+        XCTAssertEqual(reactor.currentState.isScrollToTop, true)
     }
 }
 
 private extension MyPageReactorTests {
     var userSectionModels: [MyPageSectionModel] {
-        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "알 수 없음"
 
         return [
             .init(section: .welcome(MockUser.someUser.nickname), items: []),
@@ -422,7 +424,7 @@ private extension MyPageReactorTests {
     }
 
     var guestSectionModels: [MyPageSectionModel] {
-        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "알 수 없음"
 
         return [
             .init(

--- a/Clipster/ClipsterTests/Presentation/Reactor/MyPageReactorTests.swift
+++ b/Clipster/ClipsterTests/Presentation/Reactor/MyPageReactorTests.swift
@@ -354,7 +354,7 @@ final class MyPageReactorTests: XCTestCase {
         reactor.action.onNext(.tapCell(.account(.logout)))
 
         // then
-        waitForExpectations(timeout: 1.0)
+        wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(phaseResults, [.loading, .success])
         XCTAssertTrue(logoutUseCase.didCallExecute)
         XCTAssertEqual(reactor.currentState.sectionModels, guestSectionModels)
@@ -380,11 +380,116 @@ final class MyPageReactorTests: XCTestCase {
         reactor.action.onNext(.tapCell(.account(.withdraw)))
 
         // then
-        waitForExpectations(timeout: 1.0)
+        wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(phaseResults, [.loading, .success])
         XCTAssertTrue(withdrawUseCase.didCallExecute)
         XCTAssertEqual(reactor.currentState.sectionModels, guestSectionModels)
         XCTAssertEqual(reactor.currentState.isScrollToTop, true)
+    }
+
+    func test_테마_옵션_변경() {
+        // given
+        let expectation = expectation(description: #function)
+
+        reactor.state
+            .skip(1)
+            .map { $0.sectionModels }
+            .subscribe { _ in
+                expectation.fulfill()
+            }
+            .disposed(by: disposeBag)
+
+        // when
+        reactor.action.onNext(.changeTheme(.dark))
+
+        // then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(saveThemeOptionUseCase.didCallExecute)
+        XCTAssertEqual(reactor.currentState.themeOption, .dark)
+    }
+
+    func test_저장_경로_보기__옵션_변경() {
+        // given
+        let expectation = expectation(description: #function)
+
+        reactor.state
+            .skip(1)
+            .map { $0.sectionModels }
+            .subscribe { _ in
+                expectation.fulfill()
+            }
+            .disposed(by: disposeBag)
+
+        // when
+        reactor.action.onNext(.changeSavePathLayout(.skip))
+
+        // then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(saveSavePathLayoutOptionUseCase.didCallExecute)
+        XCTAssertEqual(reactor.currentState.savePathOption, .skip)
+    }
+
+    func test_폴더_정렬_옵셜_변경() {
+        // given
+        let expectation = expectation(description: #function)
+
+        reactor.state
+            .skip(1)
+            .map { $0.sectionModels }
+            .subscribe { _ in
+                expectation.fulfill()
+            }
+            .disposed(by: disposeBag)
+
+        // when
+        reactor.action.onNext(.changeFolderSort(.title(.ascending)))
+
+        // then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(saveFolderSortOptionUseCase.didCallExecute)
+        XCTAssertEqual(reactor.currentState.folderSortOption, .title(.ascending))
+    }
+
+    func test_클립_정렬_옵셜_변경() {
+        // given
+        let expectation = expectation(description: #function)
+
+        reactor.state
+            .skip(1)
+            .map { $0.sectionModels }
+            .subscribe { _ in
+                expectation.fulfill()
+            }
+            .disposed(by: disposeBag)
+
+        // when
+        reactor.action.onNext(.changeClipSort(.title(.ascending)))
+
+        // then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(saveClipSortOptionUseCase.didCallExecute)
+        XCTAssertEqual(reactor.currentState.clipSortOption, .title(.ascending))
+    }
+
+    func test_닉네임_변경() {
+        // given
+        let expectation = expectation(description: #function)
+
+        reactor.state
+            .skip(1)
+            .map { $0.sectionModels }
+            .subscribe { _ in
+                expectation.fulfill()
+            }
+            .disposed(by: disposeBag)
+
+        // when
+        reactor.action.onNext(.changeNickName("테스트"))
+
+        // then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(updateNicknameUseCase.didCallExecute)
+        XCTAssertEqual(reactor.currentState.nickname, "테스트")
     }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
close #691 

## 📌 변경 사항 및 이유
#### 변경 전
- sectionModels를 상태(State)에 직접 보관하고, UI 갱신 시 이를 직접 수정하는 방식
- themeOption, folderSortOption 등은 별도로 관리되지 않아 상태 추적이 불명확했음
- 특정 옵션을 변경하려면 sectionModels 배열을 순회하여 원하는 item을 찾아 교체해야 했음

#### 변경 후
- sectionModels는 computed property로 변경, 각 도메인 상태 (themeOption, folderSortOption, clipSortOption, savePathOption, nickname, isLogin)는 State에서 독립적으로 관리
- 상태 변경이 생기면 해당 값만 갱신하면 되고, 전체 sectionModel은 자동으로 재계산됨
→ 상태 추적 및 변경 흐름이 명확해짐

## 📌 PR Point
- 각 상태를 개별적으로 변경하면 sectionModel의 computed property가 매번 호출되어 비효율이 발생하기 때문에 Mutation.setAllPreferences는 여러 도메인 상태를 한 번에 변경하기 위해 도입했습니다.
