### PR TITLE
URLRepository 리팩토링

### DIFF
--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -80,7 +80,6 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
                     print("\(Self.self) 스크린샷 캡처 결과 이미지가 없습니다.")
                     continuation.resume(returning: nil)
                 }
-                self.cleanupWebView()
             }
         }
     }
@@ -88,16 +87,17 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
 
 extension DefaultURLRepository {
     private func complete(with result: Result<(String, Data?), URLValidationError>) {
-        timeoutTimer?.invalidate()
-        timeoutTimer = nil
+        print("complete !!")
         guard let currentContinuation = continuation else { return }
-        currentContinuation.resume(returning: result)
         continuation = nil
+        currentContinuation.resume(returning: result)
+        DispatchQueue.main.async { [weak self] in
+            self?.cleanupWebView()
+        }
     }
 
     private func handleTimeout() {
         print("\(Self.self) WKWebView 로드 타임아웃 발생 URL: \(originalURL?.absoluteString ?? "N/A")")
-        webView?.stopLoading()
         complete(with: .failure(.timeOut))
     }
 

--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -5,11 +5,13 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
     private var continuation: CheckedContinuation<Result<(String, Data?), URLValidationError>, Never>?
     private var webView: WKWebView?
     private var timeoutTimer: Timer?
+    private var isCompleted = false
 
     func fetchHTML(from url: URL) async -> Result<(String, Data?), URLValidationError> {
         await withCheckedContinuation { continuation in
             self.cleanupWebView()
 
+            self.isCompleted = false
             self.continuation = continuation
 
             let config = WKWebViewConfiguration()
@@ -38,29 +40,6 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
 }
 
 extension DefaultURLRepository {
-    private func complete(with result: Result<(String, Data?), URLValidationError>) {
-        guard let currentContinuation = continuation else { return }
-        continuation = nil
-        currentContinuation.resume(returning: result)
-        DispatchQueue.main.async { [weak self] in
-            self?.cleanupWebView()
-        }
-    }
-
-    private func handleTimeout() {
-        print("\(Self.self) WKWebView 로드 타임아웃 발생 URL: \(originalURL?.absoluteString ?? "N/A")")
-        complete(with: .failure(.timeOut))
-    }
-
-    private func cleanupWebView() {
-        timeoutTimer?.invalidate()
-        timeoutTimer = nil
-        webView?.navigationDelegate = nil
-        webView?.stopLoading()
-        webView?.removeFromSuperview()
-        webView = nil
-    }
-
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation) {
         print("\(Self.self) WKWebView 로드 시작: \(webView.url?.absoluteString ?? "Unknown URL")")
     }
@@ -73,34 +52,9 @@ extension DefaultURLRepository {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation) {
         print("\(Self.self) WKWebView 로드 완료: \(webView.url?.absoluteString ?? "Unknown URL")")
 
-        timeoutTimer?.invalidate()
-        timeoutTimer = nil
-
         Task {
             do {
-                var checkCount = 0
-                let maxChecks = 15
-
-                while checkCount < maxChecks {
-                    let elementsAreReady = try await webView.evaluateJavaScript("checkMetaElements()") as? Bool ?? false
-
-                    if elementsAreReady {
-                        print("\(Self.self) 목표한 메타 태그 발견.")
-                        break
-                    }
-                    checkCount += 1
-                    try await Task.sleep(for: .milliseconds(200))
-                }
-
-                if checkCount == maxChecks {
-                    print("\(Self.self) 목표 메타 태그를 찾지 못 하였습니다.")
-                }
-
-                while true {
-                    let readyState = try await webView.evaluateJavaScript("document.readyState") as? String
-                    if readyState == "complete" { break }
-                    try await Task.sleep(for: .milliseconds(200))
-                }
+                try await waitForDOMContentLoaded(webView: webView)
 
                 guard let htmlString = try await webView.evaluateJavaScript("document.documentElement.outerHTML.toString()") as? String, !htmlString.isEmpty else {
                     print("\(Self.self) HTML 불러오기 실패")
@@ -125,32 +79,73 @@ extension DefaultURLRepository {
         print("\(Self.self) WKWebView 로드 중 오류 발생: \(error.localizedDescription) URL: \(webView.url?.absoluteString ?? "N/A")")
         complete(with: .failure(.unsupportedURL))
     }
+}
 
-    private func captureScreenshot(rect: CGRect? = nil) async -> Data? {
+private extension DefaultURLRepository {
+    func complete(with result: Result<(String, Data?), URLValidationError>) {
+        guard !isCompleted, let currentContinuation = continuation else { return }
+        isCompleted = true
+
+        timeoutTimer?.invalidate()
+        timeoutTimer = nil
+
+        continuation = nil
+        currentContinuation.resume(returning: result)
+        DispatchQueue.main.async { [weak self] in
+            self?.cleanupWebView()
+        }
+    }
+
+    func handleTimeout() {
+        print("\(Self.self) WKWebView 로드 타임아웃 발생 URL: \(webView?.url?.absoluteString ?? "N/A")")
+        complete(with: .failure(.timeOut))
+    }
+
+    func cleanupWebView() {
+        timeoutTimer?.invalidate()
+        timeoutTimer = nil
+        webView?.navigationDelegate = nil
+        webView?.stopLoading()
+        webView?.removeFromSuperview()
+        webView = nil
+        webView?.navigationDelegate = nil
+    }
+
+    func captureScreenshot(rect: CGRect? = nil) async -> Data? {
         guard let webView = self.webView else {
             print("\(Self.self) WKWebView 인스턴스가 없어 스크린샷을 찍을 수 없습니다.")
             return nil
         }
 
-        return await withCheckedContinuation { continuation in
-            let configuration = WKSnapshotConfiguration()
+        let configuration = WKSnapshotConfiguration()
 
-            if let rect = rect {
-                configuration.rect = rect
-            }
+        if let rect = rect {
+            configuration.rect = rect
+        }
 
-            webView.takeSnapshot(with: configuration) { image, error in
-                if let error = error {
-                    print("\(Self.self) 스크린샷 캡처 실패: \(error.localizedDescription)")
-                    continuation.resume(returning: nil)
-                } else if let image = image {
-                    print("\(Self.self) 스크린샷 캡처 성공.")
-                    continuation.resume(returning: image.jpegData(compressionQuality: 0.5))
-                } else {
-                    print("\(Self.self) 스크린샷 캡처 결과 이미지가 없습니다.")
-                    continuation.resume(returning: nil)
-                }
+        do {
+            let image = try await webView.takeSnapshot(configuration: configuration)
+            print("\(Self.self) 스크린샷 캡처 성공")
+            return image.jpegData(compressionQuality: 0.5)
+        } catch {
+            print("\(Self.self) 스크린샷 캡처 실패: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func waitForDOMContentLoaded(webView: WKWebView) async throws {
+        var checkCount = 0
+        let maxChecks = 15
+
+        while checkCount < maxChecks {
+            let elementsAreReady = try await webView.evaluateJavaScript("checkMetaElements()") as? Bool ?? false
+
+            if elementsAreReady {
+                print("\(Self.self) DOM Content 발견.")
+                break
             }
+            checkCount += 1
+            try await Task.sleep(for: .milliseconds(200))
         }
     }
 }

--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -4,7 +4,6 @@ import WebKit
 final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository {
     private var continuation: CheckedContinuation<Result<(String, Data?), URLValidationError>, Never>?
     private var webView: WKWebView?
-    private var originalURL: URL?
     private var timeoutTimer: Timer?
 
     func fetchHTML(from url: URL) async -> Result<(String, Data?), URLValidationError> {
@@ -12,7 +11,6 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
             self.cleanupWebView()
 
             self.continuation = continuation
-            self.originalURL = url
 
             let config = WKWebViewConfiguration()
             let userContentController = WKUserContentController()
@@ -61,7 +59,6 @@ extension DefaultURLRepository {
         webView?.stopLoading()
         webView?.removeFromSuperview()
         webView = nil
-        originalURL = nil
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation) {
@@ -69,7 +66,7 @@ extension DefaultURLRepository {
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation, withError error: Error) {
-        print("\(Self.self) WKWebView 초기 로드 실패: \(error.localizedDescription) URL: \(originalURL?.absoluteString ?? "N/A")")
+        print("\(Self.self) WKWebView 초기 로드 실패: \(error.localizedDescription) URL: \(webView.url?.absoluteString ?? "N/A")")
         complete(with: .failure(.unsupportedURL))
     }
 
@@ -125,7 +122,7 @@ extension DefaultURLRepository {
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation, withError error: Error) {
-        print("\(Self.self) WKWebView 로드 중 오류 발생: \(error.localizedDescription) URL: \(originalURL?.absoluteString ?? "N/A")")
+        print("\(Self.self) WKWebView 로드 중 오류 발생: \(error.localizedDescription) URL: \(webView.url?.absoluteString ?? "N/A")")
         complete(with: .failure(.unsupportedURL))
     }
 

--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -38,24 +38,6 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
         }
     }
 
-    func resolveRedirectURL(initialURL: URL) async -> URL {
-        var request = URLRequest(url: initialURL)
-        request.httpMethod = "get"
-
-        do {
-            let (_, response) = try await URLSession.shared.data(for: request)
-            if let httpResponse = response as? HTTPURLResponse,
-               let finalURL = httpResponse.url {
-                print("\(Self.self) 리디렉션 최종 URL: \(finalURL)")
-                return finalURL
-            }
-        } catch {
-            print("\(Self.self) 리디렉션 확인 실패: \(error)")
-        }
-
-        return initialURL
-    }
-
     func captureScreenshot(rect: CGRect? = nil) async -> Data? {
         guard let webView = self.webView else {
             print("\(Self.self) WKWebView 인스턴스가 없어 스크린샷을 찍을 수 없습니다.")
@@ -87,7 +69,6 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
 
 extension DefaultURLRepository {
     private func complete(with result: Result<(String, Data?), URLValidationError>) {
-        print("complete !!")
         guard let currentContinuation = continuation else { return }
         continuation = nil
         currentContinuation.resume(returning: result)

--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -37,34 +37,6 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
             }
         }
     }
-
-    func captureScreenshot(rect: CGRect? = nil) async -> Data? {
-        guard let webView = self.webView else {
-            print("\(Self.self) WKWebView 인스턴스가 없어 스크린샷을 찍을 수 없습니다.")
-            return nil
-        }
-
-        return await withCheckedContinuation { continuation in
-            let configuration = WKSnapshotConfiguration()
-
-            if let rect = rect {
-                configuration.rect = rect
-            }
-
-            webView.takeSnapshot(with: configuration) { image, error in
-                if let error = error {
-                    print("\(Self.self) 스크린샷 캡처 실패: \(error.localizedDescription)")
-                    continuation.resume(returning: nil)
-                } else if let image = image {
-                    print("\(Self.self) 스크린샷 캡처 성공.")
-                    continuation.resume(returning: image.jpegData(compressionQuality: 0.5))
-                } else {
-                    print("\(Self.self) 스크린샷 캡처 결과 이미지가 없습니다.")
-                    continuation.resume(returning: nil)
-                }
-            }
-        }
-    }
 }
 
 extension DefaultURLRepository {
@@ -155,5 +127,33 @@ extension DefaultURLRepository {
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation, withError error: Error) {
         print("\(Self.self) WKWebView 로드 중 오류 발생: \(error.localizedDescription) URL: \(originalURL?.absoluteString ?? "N/A")")
         complete(with: .failure(.unsupportedURL))
+    }
+
+    private func captureScreenshot(rect: CGRect? = nil) async -> Data? {
+        guard let webView = self.webView else {
+            print("\(Self.self) WKWebView 인스턴스가 없어 스크린샷을 찍을 수 없습니다.")
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            let configuration = WKSnapshotConfiguration()
+
+            if let rect = rect {
+                configuration.rect = rect
+            }
+
+            webView.takeSnapshot(with: configuration) { image, error in
+                if let error = error {
+                    print("\(Self.self) 스크린샷 캡처 실패: \(error.localizedDescription)")
+                    continuation.resume(returning: nil)
+                } else if let image = image {
+                    print("\(Self.self) 스크린샷 캡처 성공.")
+                    continuation.resume(returning: image.jpegData(compressionQuality: 0.5))
+                } else {
+                    print("\(Self.self) 스크린샷 캡처 결과 이미지가 없습니다.")
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
     }
 }

--- a/Clipster/Clipster/Domain/Protocol/Repository/URL/URLRepository.swift
+++ b/Clipster/Clipster/Domain/Protocol/Repository/URL/URLRepository.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol URLRepository {
-    func fetchHTML(from url: URL) async -> Result<String, URLValidationError>
+    func fetchHTML(from url: URL) async -> Result<(String, Data?), URLValidationError>
     func resolveRedirectURL(initialURL: URL) async -> URL
     func captureScreenshot(rect: CGRect?) async -> Data?
 }

--- a/Clipster/Clipster/Domain/Protocol/Repository/URL/URLRepository.swift
+++ b/Clipster/Clipster/Domain/Protocol/Repository/URL/URLRepository.swift
@@ -2,6 +2,4 @@ import Foundation
 
 protocol URLRepository {
     func fetchHTML(from url: URL) async -> Result<(String, Data?), URLValidationError>
-    func resolveRedirectURL(initialURL: URL) async -> URL
-    func captureScreenshot(rect: CGRect?) async -> Data?
 }

--- a/Clipster/Clipster/Domain/UseCase/URL/DefaultParseURLUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/URL/DefaultParseURLUseCase.swift
@@ -8,13 +8,11 @@ final class DefaultParseURLUseCase: ParseURLUseCase {
     }
 
     func execute(url: URL) async -> Result<(URLMetadata?, Bool), URLValidationError> {
-        let resolveFinalURL = await urlRepository.resolveRedirectURL(initialURL: url)
-
-        let htmlResult = await urlRepository.fetchHTML(from: resolveFinalURL)
+        let htmlResult = await urlRepository.fetchHTML(from: url)
 
         switch htmlResult {
         case .success(let (html, screenshotData)):
-            let parsedMetadata = createParsedURLMetadata(url: sanitizeURL, html: html, screenshotData: screenshotData)
+            let parsedMetadata = createParsedURLMetadata(url: url, html: html, screenshotData: screenshotData)
             return .success((parsedMetadata, true))
 
         case .failure(let error):

--- a/Clipster/Clipster/Domain/UseCase/URL/DefaultParseURLUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/URL/DefaultParseURLUseCase.swift
@@ -13,9 +13,8 @@ final class DefaultParseURLUseCase: ParseURLUseCase {
         let htmlResult = await urlRepository.fetchHTML(from: resolveFinalURL)
 
         switch htmlResult {
-        case .success(let html):
-            let screenshotData = await urlRepository.captureScreenshot(rect: nil)
-            let parsedMetadata = createParsedURLMetadata(url: url, html: html, screenshotData: screenshotData)
+        case .success(let (html, screenshotData)):
+            let parsedMetadata = createParsedURLMetadata(url: sanitizeURL, html: html, screenshotData: screenshotData)
             return .success((parsedMetadata, true))
 
         case .failure(let error):

--- a/Clipster/ClipsterTests/Domain/Stub/Repository/StubURLRepository.swift
+++ b/Clipster/ClipsterTests/Domain/Stub/Repository/StubURLRepository.swift
@@ -2,29 +2,18 @@ import Foundation
 @testable import Clipster
 
 final class StubURLRepository: URLRepository {
-    let resolvedRedirectURL: URL
     let htmlResult: String
     let capturedScreenshot: Data?
 
     init(
-        resolveRedirectURL: URL,
         htmlResult: String,
         captureScreenshot: Data?
     ) {
-        self.resolvedRedirectURL = resolveRedirectURL
         self.htmlResult = htmlResult
         self.capturedScreenshot = captureScreenshot
     }
 
-    func fetchHTML(from url: URL) async -> Result<String, URLValidationError> {
-        return .success(htmlResult)
-    }
-    
-    func resolveRedirectURL(initialURL: URL) async -> URL {
-        return resolvedRedirectURL
-    }
-    
-    func captureScreenshot(rect: CGRect?) async -> Data? {
-        return capturedScreenshot
+    func fetchHTML(from url: URL) async -> Result<(String, Data?), URLValidationError> {
+        return .success((htmlResult, capturedScreenshot))
     }
 }

--- a/Clipster/ClipsterTests/Domain/UseCase/URL/ParseURLUseCaseTests.swift
+++ b/Clipster/ClipsterTests/Domain/UseCase/URL/ParseURLUseCaseTests.swift
@@ -8,7 +8,6 @@ final class ParseURLUseCaseTests: XCTestCase {
         super.setUp()
         useCase = DefaultParseURLUseCase(
             urlMetaRepository: StubURLRepository(
-                resolveRedirectURL: URL(string: "www.google.com")!,
                 htmlResult: """
                 <!DOCTYPE html>
                 <html lang="en">
@@ -191,7 +190,6 @@ final class ParseURLUseCaseTests: XCTestCase {
             """
         let mockScreenshot = "image".data(using: .utf8)!
         let repo = StubURLRepository(
-            resolveRedirectURL: URL(string: "https://resolved.com")!,
             htmlResult:  mockHTML,
             captureScreenshot: mockScreenshot
         )
@@ -218,7 +216,6 @@ final class ParseURLUseCaseTests: XCTestCase {
             """
         let mockScreenshot = "image".data(using: .utf8)!
         let repo = StubURLRepository(
-            resolveRedirectURL: URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")!,
             htmlResult:  mockHTML,
             captureScreenshot: mockScreenshot
         )
@@ -246,7 +243,6 @@ final class ParseURLUseCaseTests: XCTestCase {
                 </html>
             """
         let repo = StubURLRepository(
-            resolveRedirectURL: URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")!,
             htmlResult:  mockHTML,
             captureScreenshot: nil
         )

--- a/Clipster/ShareExtension/Info.plist
+++ b/Clipster/ShareExtension/Info.plist
@@ -25,5 +25,10 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>ShareExtension.ShareViewController</string>
 	</dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## 📌 관련 이슈

close #696

## 📌 변경 사항 및 이유
- 스크린샷 캡처 시점을 UseCase에서 결정하는 것이 아닌 Repository에서 결정하고 데이터를 생성할 수 있도록 변경하였습니다.
- captureScreenshot() 스크린샷 캡처 코드를 async/await 적용하였습니다.
- DOM 관련 동적 변경 이후 HTML을 파싱할 수 있도록 구문을 추가하였습니다.
- 최초 요청부터 리턴까지의 전체적인 동작 시간을 보다 정확히 제한할 수 있도록 수정하였습니다.(timeoutTimer 프로퍼티)
- WebView를 초기화/클린하는 시점을 변경하여 URLRepository가 안정적으로 동작할 수 있도록 개선하였습니다. (cleanupWebView() 메소드)
- 리다이렉션 주소를 구하는 메소드를 삭제하였습니다.
- 수정된 URLRepository에 따라 테스트 코드를 수정 반영하였습니다.
- ShareExtension에도 ATS 허용을 info.plist에 추가하였습니다.

