### PR TITLE
원티드 공유 링크 입력 시 메타데이터 추출 실패 수정

### DIFF
--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -46,6 +46,11 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
 }
 
 extension DefaultURLRepository {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
+        print("\(Self.self) decidePolicyForAction: \(webView.url?.absoluteString ?? "Unknown URL")")
+        decisionHandler(.allow)
+    }
+
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation) {
         print("\(Self.self) WKWebView 로드 시작: \(webView.url?.absoluteString ?? "Unknown URL")")
     }

--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -6,9 +6,15 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
     private var webView: WKWebView?
     private var timeoutTimer: Timer?
     private var isCompleted = false
+    private var didAttemptRetry = false
+    private var lastKnownContentURL: URL?
 
     func fetchHTML(from url: URL) async -> Result<(String, Data?), URLValidationError> {
         await withCheckedContinuation { continuation in
+            self.didAttemptRetry = false
+            self.lastKnownContentURL = url
+            let urlForFirstRequest = url
+
             self.cleanupWebView()
 
             self.isCompleted = false
@@ -29,7 +35,7 @@ final class DefaultURLRepository: NSObject, WKNavigationDelegate, URLRepository 
             self.webView = WKWebView(frame: webViewFrame, configuration: config)
             self.webView?.navigationDelegate = self
 
-            let request = URLRequest(url: url)
+            let request = URLRequest(url: urlForFirstRequest)
             self.webView?.load(request)
 
             self.timeoutTimer = Timer.scheduledTimer(withTimeInterval: 20, repeats: false) { [weak self] _ in
@@ -46,6 +52,11 @@ extension DefaultURLRepository {
 
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation) {
         print("\(Self.self) WKWebView 리다이렉션 발생 \(webView.url?.absoluteString ?? "Unknown URL")")
+        if let newURL = webView.url {
+            if !newURL.absoluteString.contains("login") && !newURL.absoluteString.contains("sign") {
+                self.lastKnownContentURL = newURL
+            }
+        }
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation, withError error: Error) {
@@ -58,6 +69,29 @@ extension DefaultURLRepository {
 
         Task {
             do {
+                if await self.isLoginPage(webView: webView) {
+                    if !self.didAttemptRetry,
+                       let contentURL = self.lastKnownContentURL,
+                       let strippedURL = contentURL.strippingQueryParameters()
+                    {
+                        if contentURL.absoluteString != strippedURL.absoluteString {
+                            print("\(Self.self) 로그인 페이지 감지, 파라미터 제거 후 재 요청 시도 \(strippedURL)")
+                            self.didAttemptRetry = true
+
+                            let request = URLRequest(url: strippedURL)
+                            webView.load(request)
+                            return
+                        }
+                    }
+
+                    if webView.url == nil {
+                        self.complete(with: .failure(.detectedLoginPage))
+                    } else {
+                        self.complete(with: .failure(.notFoundedWKURL))
+                    }
+                    return
+                }
+
                 try await waitForDOMContentLoaded(webView: webView)
 
                 guard let htmlString = try await webView.evaluateJavaScript("document.documentElement.outerHTML.toString()") as? String, !htmlString.isEmpty else {
@@ -151,5 +185,43 @@ private extension DefaultURLRepository {
             checkCount += 1
             try await Task.sleep(for: .milliseconds(200))
         }
+    }
+
+    func isLoginPage(webView: WKWebView) async -> Bool {
+        let script = """
+            (function() {
+                const loginKeywordsInURL = ['login', 'sign', 'auth', 'account'];
+                const currentURL = window.location.href.toLowerCase();
+                if (loginKeywordsInURL.some(keyword => currentURL.includes(keyword))) {
+                    return true;
+                }
+                if (document.querySelector("input[type='password']")) {
+                    return true;
+                }
+                const loginKeywordsInTitle = ['로그인', 'login', 'sign'];
+                const pageTitle = document.title.toLowerCase();
+            
+                if (loginKeywordsInTitle.some(keyword => pageTitle.includes(keyword))) {
+                    return true;
+                }
+                return false
+            })();
+            """
+        if let result = try? await webView.evaluateJavaScript(script) as? Bool {
+            return result
+        }
+
+        return false
+    }
+}
+
+extension URL {
+    func strippingQueryParameters() -> URL? {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
+            return nil
+        }
+
+        components.queryItems = nil
+        return components.url
     }
 }

--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -44,6 +44,10 @@ extension DefaultURLRepository {
         print("\(Self.self) WKWebView 로드 시작: \(webView.url?.absoluteString ?? "Unknown URL")")
     }
 
+    func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation) {
+        print("\(Self.self) WKWebView 리다이렉션 발생 \(webView.url?.absoluteString ?? "Unknown URL")")
+    }
+
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation, withError error: Error) {
         print("\(Self.self) WKWebView 초기 로드 실패: \(error.localizedDescription) URL: \(webView.url?.absoluteString ?? "N/A")")
         complete(with: .failure(.unsupportedURL))

--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -78,7 +78,7 @@ extension DefaultURLRepository {
                 if await self.isLoginPage(webView: webView) {
                     if !self.didAttemptRetry,
                        let contentURL = self.lastKnownContentURL,
-                       let strippedURL = contentURL.strippingQueryParameters() {
+                       let strippedURL = self.strippingQueryParameters(url: contentURL) {
                         if contentURL.absoluteString != strippedURL.absoluteString {
                             print("\(Self.self) 로그인 페이지 감지, 파라미터 제거 후 재 요청 시도 \(strippedURL)")
                             self.didAttemptRetry = true
@@ -218,11 +218,9 @@ private extension DefaultURLRepository {
 
         return false
     }
-}
 
-extension URL {
-    func strippingQueryParameters() -> URL? {
-        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
+    func strippingQueryParameters(url: URL) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
             return nil
         }
 

--- a/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URL/DefaultURLRepository.swift
@@ -58,7 +58,8 @@ extension DefaultURLRepository {
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation) {
         print("\(Self.self) WKWebView 리다이렉션 발생 \(webView.url?.absoluteString ?? "Unknown URL")")
         if let newURL = webView.url {
-            if !newURL.absoluteString.contains("login") && !newURL.absoluteString.contains("sign") {
+            if !newURL.absoluteString.contains("login") &&
+                !newURL.absoluteString.contains("sign") {
                 self.lastKnownContentURL = newURL
             }
         }
@@ -77,8 +78,7 @@ extension DefaultURLRepository {
                 if await self.isLoginPage(webView: webView) {
                     if !self.didAttemptRetry,
                        let contentURL = self.lastKnownContentURL,
-                       let strippedURL = contentURL.strippingQueryParameters()
-                    {
+                       let strippedURL = contentURL.strippingQueryParameters() {
                         if contentURL.absoluteString != strippedURL.absoluteString {
                             print("\(Self.self) 로그인 페이지 감지, 파라미터 제거 후 재 요청 시도 \(strippedURL)")
                             self.didAttemptRetry = true
@@ -205,7 +205,7 @@ private extension DefaultURLRepository {
                 }
                 const loginKeywordsInTitle = ['로그인', 'login', 'sign'];
                 const pageTitle = document.title.toLowerCase();
-            
+
                 if (loginKeywordsInTitle.some(keyword => pageTitle.includes(keyword))) {
                     return true;
                 }

--- a/Clipster/Clipster/Domain/Error/URLValidationError.swift
+++ b/Clipster/Clipster/Domain/Error/URLValidationError.swift
@@ -4,5 +4,6 @@ enum URLValidationError: Error {
     case unsupportedURL
     case emptyHTMLContent
     case notFoundedWKURL
+    case detectedLoginPage
     case unknown
 }


### PR DESCRIPTION
## 📌 관련 이슈

close #704 

## 📌 변경 사항 및 이유

- 원티드 공유 링크 입력 시 메타데이터 추출 실패가 발생합니다. 원티드는 추천인 제도가 존재하여 공유하기로 URL을 전달할 경우 파라미터에 `recommend_Key` 파라미터가 포함되며, URL을 전달 받은 측에서 웹 페이지를 로드할 때 로그인을 요구 받게 됩니다. 
- 따라서 login, sign 등과 같은 로그인과 관련된 URL로 리다이렉션 될 경우, 리다이렉션  발생 이전 주소를 갱신하여 파라미터를 제거한 상태로 WebView로 재요청하는 로직을 추가하였습니다.

- WKWebView 동작 과정에서 호출되는 메소드를 추가하여 로그를 출력할 수 있도록 하였습니다.

## 📌 PR Point
머지 타겟이 dev가 아니기 때문에 #706 PR 먼저 검토해주시면 감사하겠습니다.
