### PR TITLE
탭바VC 코드 정리 및 Pop to Root 처리

### DIFF
--- a/Clipster/Clipster/Presentation/Coordinator/TabBar/TabBarCoordinator.swift
+++ b/Clipster/Clipster/Presentation/Coordinator/TabBar/TabBarCoordinator.swift
@@ -34,7 +34,7 @@ final class TabBarCoordinator: Coordinator {
 }
 
 extension TabBarCoordinator {
-    func didSelect(tab: TabBarMode) {
+    func didSelect(tab: TabItem) {
         guard children.indices.contains(tab.rawValue) else { return }
         let targetVC = children[tab.rawValue].navigationController
         tabBarController.switchTo(targetVC)

--- a/Clipster/Clipster/Presentation/Coordinator/TabBar/TabBarCoordinator.swift
+++ b/Clipster/Clipster/Presentation/Coordinator/TabBar/TabBarCoordinator.swift
@@ -11,6 +11,8 @@ final class TabBarCoordinator: Coordinator {
         TabBarViewController(coordinator: self)
     }()
 
+    private var currentTab: TabItem = .defaultTab
+
     init(navigationController: UINavigationController, diContainer: DIContainer) {
         self.navigationController = navigationController
         self.diContainer = diContainer
@@ -30,14 +32,39 @@ final class TabBarCoordinator: Coordinator {
         myPageCoordinator.start()
 
         navigationController.setViewControllers([tabBarController], animated: false)
+
+        didSelect(tab: currentTab)
     }
 }
 
 extension TabBarCoordinator {
-    func didSelect(tab: TabItem) {
+    func didTap(tab: TabItem) {
         guard children.indices.contains(tab.rawValue) else { return }
-        let targetVC = children[tab.rawValue].navigationController
-        tabBarController.switchTo(targetVC)
+
+        if tab != currentTab {
+            didSelect(tab: tab)
+        } else {
+            didReselect(tab: tab)
+        }
+    }
+
+    func didSelect(tab: TabItem) {
+        let targetNav = children[tab.rawValue].navigationController
+        tabBarController.switchTo(targetNav)
+        tabBarController.updateSelectedTab(tab)
+        currentTab = tab
+    }
+
+    func didReselect(tab: TabItem) {
+        let targetNav = children[tab.rawValue].navigationController
+
+        if targetNav.presentedViewController != nil {
+            targetNav.dismiss(animated: false)
+        }
+
+        if targetNav.viewControllers.count > 1 {
+            targetNav.popToRootViewController(animated: true)
+        }
     }
 }
 

--- a/Clipster/Clipster/Presentation/Scene/TabBar/SubView/TabBarView.swift
+++ b/Clipster/Clipster/Presentation/Scene/TabBar/SubView/TabBarView.swift
@@ -5,13 +5,13 @@ import UIKit
 
 final class TabBarView: UIView {
     enum Action {
-        case tapHome
-        case tapSearch
-        case tapUser
+        case tap(TabItem)
     }
 
     private let disposeBag = DisposeBag()
     let action = PublishRelay<Action>()
+
+    private let items = TabItem.allCases
 
     private let baseBackgroundView: UIView = {
         let view = UIView()
@@ -28,29 +28,17 @@ final class TabBarView: UIView {
         return stack
     }()
 
-    private let homeContainer = UIView()
-    private let searchContainer = UIView()
-    private let userContainer = UIView()
-
-    private let homeButton: UIButton = {
-        let button = UIButton()
-        button.setImage(.home.withTintColor(.textPrimary), for: .normal)
-        button.setImage(.homeSelected, for: .selected)
-        return button
+    private lazy var containerViews: [TabItem: UIView] = {
+        Dictionary(uniqueKeysWithValues: items.map { ($0, UIView()) })
     }()
 
-    private let searchButton: UIButton = {
-        let button = UIButton()
-        button.setImage(.search.withTintColor(.textPrimary), for: .normal)
-        button.setImage(.searchSelected, for: .selected)
-        return button
-    }()
-
-    private let userButton: UIButton = {
-        let button = UIButton()
-        button.setImage(.user.withTintColor(.textPrimary), for: .normal)
-        button.setImage(.userSelected, for: .selected)
-        return button
+    private lazy var tabButtons: [TabItem: UIButton] = {
+        Dictionary(uniqueKeysWithValues: items.map { mode in
+            let button = UIButton()
+            button.setImage(mode.unselectedImage.withTintColor(.textPrimary), for: .normal)
+            button.setImage(mode.selectedImage, for: .selected)
+            return (mode, button)
+        })
     }()
 
     override init(frame: CGRect) {
@@ -71,13 +59,9 @@ final class TabBarView: UIView {
         layer.shadowPath = path.cgPath
     }
 
-    func updateSelectedTab(_ mode: TabBarMode) {
-        [
-            homeButton,
-            searchButton,
-            userButton
-        ].enumerated().forEach { index, button in
-            button.isSelected = (index == mode.rawValue)
+    func updateSelectedTab(_ mode: TabItem) {
+        tabButtons.forEach { key, button in
+            button.isSelected = (key == mode)
         }
     }
 }
@@ -92,6 +76,7 @@ private extension TabBarView {
 
     func setAttributes() {
         backgroundColor = .background
+
         layer.cornerRadius = 32
         layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         layer.shadowColor = UIColor.black.cgColor
@@ -102,20 +87,17 @@ private extension TabBarView {
     }
 
     func setHierarchy() {
-        [
-            baseBackgroundView,
-            stackView
-        ].forEach { addSubview($0) }
+        addSubview(baseBackgroundView)
+        addSubview(stackView)
 
-        [
-            homeContainer,
-            searchContainer,
-            userContainer
-        ].forEach { stackView.addArrangedSubview($0) }
+        items.forEach { mode in
+            guard let container = containerViews[mode],
+                  let button = tabButtons[mode]
+            else { return }
 
-        homeContainer.addSubview(homeButton)
-        searchContainer.addSubview(searchButton)
-        userContainer.addSubview(userButton)
+            stackView.addArrangedSubview(container)
+            container.addSubview(button)
+        }
     }
 
     func setConstraints() {
@@ -127,30 +109,20 @@ private extension TabBarView {
             make.edges.equalToSuperview()
         }
 
-        homeButton.snp.makeConstraints { make in
-            make.top.equalToSuperview()
-            make.horizontalEdges.equalToSuperview()
-            make.height.equalTo(64)
-        }
-
-        searchButton.snp.makeConstraints { make in
-            make.top.equalToSuperview()
-            make.horizontalEdges.equalToSuperview()
-            make.height.equalTo(64)
-        }
-
-        userButton.snp.makeConstraints { make in
-            make.top.equalToSuperview()
-            make.horizontalEdges.equalToSuperview()
-            make.height.equalTo(64)
+        tabButtons.forEach { _, button in
+            button.snp.makeConstraints { make in
+                make.top.equalToSuperview()
+                make.horizontalEdges.equalToSuperview()
+                make.height.equalTo(64)
+            }
         }
     }
 
     func setBindings() {
         Observable.merge(
-            homeButton.rx.tap.map { Action.tapHome },
-            searchButton.rx.tap.map { Action.tapSearch },
-            userButton.rx.tap.map { Action.tapUser }
+            tabButtons.map { (mode, button) in
+                button.rx.tap.map { Action.tap(mode) }
+            }
         )
         .bind(to: action)
         .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/TabBar/TabBarMode.swift
+++ b/Clipster/Clipster/Presentation/Scene/TabBar/TabBarMode.swift
@@ -1,5 +1,0 @@
-enum TabBarMode: Int {
-    case home = 0
-    case search = 1
-    case myPage = 2
-}

--- a/Clipster/Clipster/Presentation/Scene/TabBar/TabItem.swift
+++ b/Clipster/Clipster/Presentation/Scene/TabBar/TabItem.swift
@@ -4,6 +4,8 @@ enum TabItem: Int, CaseIterable {
     case home
     case search
     case myPage
+
+    static var defaultTab: TabItem = .home
 }
 
 extension TabItem {

--- a/Clipster/Clipster/Presentation/Scene/TabBar/TabItem.swift
+++ b/Clipster/Clipster/Presentation/Scene/TabBar/TabItem.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+enum TabItem: Int, CaseIterable {
+    case home
+    case search
+    case myPage
+}
+
+extension TabItem {
+    var selectedImage: UIImage {
+        switch self {
+        case .home:
+            return .homeSelected
+        case .search:
+            return .searchSelected
+        case .myPage:
+            return .userSelected
+        }
+    }
+
+    var unselectedImage: UIImage {
+        switch self {
+        case .home:
+            return .home
+        case .search:
+            return .search
+        case .myPage:
+            return .user
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/TabBar/ViewController/TabBarController.swift
+++ b/Clipster/Clipster/Presentation/Scene/TabBar/ViewController/TabBarController.swift
@@ -9,7 +9,6 @@ final class TabBarViewController: UIViewController {
     private weak var coordinator: TabBarCoordinator?
 
     private var currentVC: UIViewController?
-    private let selectedTab = BehaviorRelay<TabItem>(value: .defaultTab)
 
     private var lastTabBarHeight: CGFloat = 0
 
@@ -58,6 +57,10 @@ final class TabBarViewController: UIViewController {
         vc.didMove(toParent: self)
         currentVC = vc
     }
+
+    func updateSelectedTab(_ item: TabItem) {
+        tabBarView.updateSelectedTab(item)
+    }
 }
 
 private extension TabBarViewController {
@@ -84,19 +87,9 @@ private extension TabBarViewController {
         tabBarView.action
             .bind { [weak self] action in
                 switch action {
-                case .tap(let mode):
-                    self?.selectedTab.accept(mode)
+                case .tap(let item):
+                    self?.coordinator?.didTap(tab: item)
                 }
-            }
-            .disposed(by: disposeBag)
-
-        selectedTab
-            .distinctUntilChanged()
-            .subscribe { [weak self] mode in
-                guard let self else { return }
-
-                tabBarView.updateSelectedTab(mode)
-                coordinator?.didSelect(tab: mode)
             }
             .disposed(by: disposeBag)
     }

--- a/Clipster/Clipster/Presentation/Scene/TabBar/ViewController/TabBarController.swift
+++ b/Clipster/Clipster/Presentation/Scene/TabBar/ViewController/TabBarController.swift
@@ -9,7 +9,7 @@ final class TabBarViewController: UIViewController {
     private weak var coordinator: TabBarCoordinator?
 
     private var currentVC: UIViewController?
-    private let selectedTab = BehaviorRelay<TabBarMode>(value: .home)
+    private let selectedTab = BehaviorRelay<TabItem>(value: .home)
 
     init(coordinator: TabBarCoordinator) {
         self.coordinator = coordinator
@@ -42,10 +42,10 @@ final class TabBarViewController: UIViewController {
         addChild(vc)
         view.insertSubview(vc.view, belowSubview: tabBarView)
 
-        vc.view.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalTo(tabBarView.snp.top)
+        vc.view.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.horizontalEdges.equalToSuperview()
+            make.bottom.equalTo(tabBarView.snp.top)
         }
 
         vc.didMove(toParent: self)
@@ -69,24 +69,18 @@ private extension TabBarViewController {
         let bottomInset = view.safeAreaInsets.bottom
         let tabBarHeight = bottomInset > 0 ? 100 : 64
 
-        tabBarView.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalToSuperview()
-            $0.height.equalTo(tabBarHeight)
+        tabBarView.snp.makeConstraints { make in
+            make.leading.trailing.bottom.equalToSuperview()
+            make.height.equalTo(tabBarHeight)
         }
     }
 
     func setBindings() {
         tabBarView.action
             .bind { [weak self] action in
-                guard let self else { return }
-
                 switch action {
-                case .tapHome:
-                    selectedTab.accept(.home)
-                case .tapSearch:
-                    selectedTab.accept(.search)
-                case .tapUser:
-                    selectedTab.accept(.myPage)
+                case .tap(let mode):
+                    self?.selectedTab.accept(mode)
                 }
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/TabBar/ViewController/TabBarController.swift
+++ b/Clipster/Clipster/Presentation/Scene/TabBar/ViewController/TabBarController.swift
@@ -11,6 +11,8 @@ final class TabBarViewController: UIViewController {
     private var currentVC: UIViewController?
     private let selectedTab = BehaviorRelay<TabItem>(value: .defaultTab)
 
+    private var lastTabBarHeight: CGFloat = 0
+
     init(coordinator: TabBarCoordinator) {
         self.coordinator = coordinator
         super.init(nibName: nil, bundle: nil)
@@ -27,10 +29,15 @@ final class TabBarViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        let baseTabBarHeight: CGFloat = 64
         let bottomInset = view.safeAreaInsets.bottom
-        let tabBarHeight = bottomInset > 0 ? 100 : 64
-        tabBarView.snp.updateConstraints {
-            $0.height.equalTo(tabBarHeight)
+        let tabBarHeight = baseTabBarHeight + bottomInset
+
+        guard lastTabBarHeight != tabBarHeight else { return }
+
+        lastTabBarHeight = tabBarHeight
+        tabBarView.snp.updateConstraints { make in
+            make.height.equalTo(tabBarHeight)
         }
     }
 
@@ -66,12 +73,10 @@ private extension TabBarViewController {
     }
 
     func setConstraints() {
-        let bottomInset = view.safeAreaInsets.bottom
-        let tabBarHeight = bottomInset > 0 ? 100 : 64
-
         tabBarView.snp.makeConstraints { make in
-            make.leading.trailing.bottom.equalToSuperview()
-            make.height.equalTo(tabBarHeight)
+            make.horizontalEdges.equalToSuperview()
+            make.bottom.equalToSuperview()
+            make.height.equalTo(1)
         }
     }
 

--- a/Clipster/Clipster/Presentation/Scene/TabBar/ViewController/TabBarController.swift
+++ b/Clipster/Clipster/Presentation/Scene/TabBar/ViewController/TabBarController.swift
@@ -9,7 +9,7 @@ final class TabBarViewController: UIViewController {
     private weak var coordinator: TabBarCoordinator?
 
     private var currentVC: UIViewController?
-    private let selectedTab = BehaviorRelay<TabItem>(value: .home)
+    private let selectedTab = BehaviorRelay<TabItem>(value: .defaultTab)
 
     init(coordinator: TabBarCoordinator) {
         self.coordinator = coordinator


### PR DESCRIPTION
## 📌 관련 이슈

close #708 

## 📌 변경 사항 및 이유
- TabBarMode -> TabItem 으로 이름 변경
- TabItem.allCases 기반으로 map을 사용해 컨테이너/버튼을 일괄 생성하도록 리팩터링하여 유지보수성과 확장성 개선
- TabItem 열거형의 기본탭 타입변수 추가
- 홈 인디케이터의 높이를 임의로 정의하는것이 아닌 safeAreaInsets 기준으로 정의하도록 변경
- 중복 탭 시 root로 pop 하는 기능 추가

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/c51c1b3d-9a1a-4454-a83a-8be0f765db9b" width="250px"> |

## 📌 PR Point
- Presentation/TabBar/TabItem의 위치를 Presentation/Model로 옮겨 Model 폴더 안에 Display, Tab 이렇게 2개로 폴더링 하는 방법은 어떠신가요?