### PR TITLE
Folder, Clip Storage의 비즈니스 로직을 Repository로 이동

### DIFF
--- a/Clipster/Clipster/Data/Persistence/DefaultClipStorage.swift
+++ b/Clipster/Clipster/Data/Persistence/DefaultClipStorage.swift
@@ -9,112 +9,40 @@ final class DefaultClipStorage: ClipStorage {
         self.mapper = mapper
     }
 
-    func fetchClip(by id: UUID) async -> Result<Clip, CoreDataError> {
-        await withCheckedContinuation { continuation in
-            container.performBackgroundTask { [weak self] context in
-                guard let self else { return }
+    func fetchClip(
+        predicate: NSPredicate,
+    ) async -> Result<Clip, CoreDataError> {
+        let result = await fetchClips(predicate: predicate, fetchLimit: 1)
 
-                let request = ClipEntity.fetchRequest()
-                request.predicate = NSPredicate(format: "id == %@ AND deletedAt == nil", id as CVarArg)
-                request.fetchLimit = 1
-
-                do {
-                    guard let entity = try context.fetch(request).first else {
-                        print("\(Self.self): ❌ Failed to fetch: Entity not found")
-                        continuation.resume(returning: .failure(.entityNotFound))
-                        return
-                    }
-                    guard let clip = mapper.clip(from: entity) else {
-                        print("\(Self.self): ❌ Failed to fetch: Mapping failed")
-                        continuation.resume(returning: .failure(.mapFailed))
-                        return
-                    }
-                    print("\(Self.self): ✅ Fetch successfully")
-                    continuation.resume(returning: .success(clip))
-                } catch {
-                    print("\(Self.self): ❌ Failed to fetch: \(error.localizedDescription)")
-                    continuation.resume(returning: .failure(.fetchFailed(error.localizedDescription)))
-                }
+        switch result {
+        case .success(let clips):
+            if let clip = clips.first {
+                return .success(clip)
+            } else {
+                return .failure(.entityNotFound)
             }
+        case .failure(let error):
+            return .failure(error)
         }
     }
 
-    func fetchAllClips() async -> Result<[Clip], CoreDataError> {
+    func fetchClips(
+        predicate: NSPredicate,
+        fetchLimit: Int,
+    ) async -> Result<[Clip], CoreDataError> {
         await withCheckedContinuation { continuation in
             container.performBackgroundTask { [weak self] context in
                 guard let self else { return }
 
                 let request = ClipEntity.fetchRequest()
-                request.predicate = NSPredicate(format: "deletedAt == nil")
+                request.predicate = predicate
+                request.fetchLimit = fetchLimit
 
                 do {
                     let entities = try context.fetch(request)
-                    let allClips = entities.compactMap(mapper.clip)
+                    let clips = entities.compactMap(mapper.clip)
                     print("\(Self.self): ✅ Fetch successfully")
-                    continuation.resume(returning: .success(allClips))
-                } catch {
-                    print("\(Self.self): ❌ Failed to fetch: \(error.localizedDescription)")
-                    continuation.resume(returning: .failure(.fetchFailed(error.localizedDescription)))
-                }
-            }
-        }
-    }
-
-    func fetchTopLevelClips() async -> Result<[Clip], CoreDataError> {
-        await withCheckedContinuation { continuation in
-            container.performBackgroundTask { [weak self] context in
-                guard let self else { return }
-
-                let request = ClipEntity.fetchRequest()
-                request.predicate = NSPredicate(format: "folder == nil AND deletedAt == nil")
-
-                do {
-                    let entities = try context.fetch(request)
-                    let topLevelClips = entities.compactMap(mapper.clip)
-                    print("\(Self.self): ✅ Fetch successfully")
-                    continuation.resume(returning: .success(topLevelClips))
-                } catch {
-                    print("\(Self.self): ❌ Failed to fetch: \(error.localizedDescription)")
-                    continuation.resume(returning: .failure(.fetchFailed(error.localizedDescription)))
-                }
-            }
-        }
-    }
-
-    func fetchUnvisitedClips() async -> Result<[Clip], CoreDataError> {
-        await withCheckedContinuation { continuation in
-            container.performBackgroundTask { [weak self] context in
-                guard let self else { return }
-
-                let request = ClipEntity.fetchRequest()
-                request.predicate = NSPredicate(format: "lastVisitedAt == nil AND deletedAt == nil")
-
-                do {
-                    let entities = try context.fetch(request)
-                    let unvisitedClips = entities.compactMap(mapper.clip)
-                    print("\(Self.self): ✅ Fetch successfully")
-                    continuation.resume(returning: .success(unvisitedClips))
-                } catch {
-                    print("\(Self.self): ❌ Failed to fetch: \(error.localizedDescription)")
-                    continuation.resume(returning: .failure(.fetchFailed(error.localizedDescription)))
-                }
-            }
-        }
-    }
-
-    func fetchRecentVisitedClips(for ids: [UUID]) async -> Result<[Clip], CoreDataError> {
-        await withCheckedContinuation { continuation in
-            container.performBackgroundTask { [weak self] context in
-                guard let self else { return }
-
-                let request = ClipEntity.fetchRequest()
-                request.predicate = NSPredicate(format: "id IN %@ AND deletedAt == nil", ids)
-
-                do {
-                    let entities = try context.fetch(request)
-                    let recentVisitedClips = entities.compactMap(mapper.clip)
-                    print("\(Self.self): ✅ Fetch successfully")
-                    continuation.resume(returning: .success(recentVisitedClips))
+                    continuation.resume(returning: .success(clips))
                 } catch {
                     print("\(Self.self): ❌ Failed to fetch: \(error.localizedDescription)")
                     continuation.resume(returning: .failure(.fetchFailed(error.localizedDescription)))

--- a/Clipster/Clipster/Data/Persistence/DefaultFolderStorage.swift
+++ b/Clipster/Clipster/Data/Persistence/DefaultFolderStorage.swift
@@ -9,46 +9,34 @@ final class DefaultFolderStorage: FolderStorage {
         self.mapper = mapper
     }
 
-    func fetchFolder(by id: UUID) async -> Result<Folder, CoreDataError> {
-        await withCheckedContinuation { continuation in
-            container.performBackgroundTask { [weak self] context in
-                guard let self else { return }
+    func fetchFolder(
+        predicate: NSPredicate
+    ) async -> Result<Folder, CoreDataError> {
+        let result = await fetchFolders(predicate: predicate, fetchLimit: 1)
 
-                let request = FolderEntity.fetchRequest()
-                request.predicate = NSPredicate(format: "id == %@ AND deletedAt == nil", id as CVarArg)
-                request.fetchLimit = 1
-
-                do {
-                    guard let entity = try context.fetch(request).first else {
-                        print("\(Self.self): ❌ Failed to fetch: Entity not found")
-                        continuation.resume(returning: .failure(.entityNotFound))
-                        return
-                    }
-
-                    filterFolderRecursively(entity)
-
-                    guard let folder = mapper.folder(from: entity) else {
-                        print("\(Self.self): ❌ Failed to fetch: Mapping failed")
-                        continuation.resume(returning: .failure(.mapFailed))
-                        return
-                    }
-                    print("\(Self.self): ✅ Fetch successfully")
-                    continuation.resume(returning: .success(folder))
-                } catch {
-                    print("\(Self.self): ❌ Failed to fetch: \(error.localizedDescription)")
-                    continuation.resume(returning: .failure(.fetchFailed(error.localizedDescription)))
-                }
+        switch result {
+        case .success(let folders):
+            if let folder = folders.first {
+                return .success(folder)
+            } else {
+                return .failure(.entityNotFound)
             }
+        case .failure(let error):
+            return .failure(error)
         }
     }
 
-    func fetchAllFolders() async -> Result<[Folder], CoreDataError> {
+    func fetchFolders(
+        predicate: NSPredicate,
+        fetchLimit: Int
+    ) async -> Result<[Folder], CoreDataError> {
         await withCheckedContinuation { continuation in
             container.performBackgroundTask { [weak self] context in
                 guard let self else { return }
 
                 let request = FolderEntity.fetchRequest()
-                request.predicate = NSPredicate(format: "deletedAt == nil")
+                request.predicate = predicate
+                request.fetchLimit = fetchLimit
 
                 do {
                     let entities = try context.fetch(request)
@@ -59,31 +47,6 @@ final class DefaultFolderStorage: FolderStorage {
                     let allFolders = entities.compactMap(mapper.folder)
                     print("\(Self.self): ✅ Fetch successfully")
                     continuation.resume(returning: .success(allFolders))
-                } catch {
-                    print("\(Self.self): ❌ Failed to fetch: \(error.localizedDescription)")
-                    continuation.resume(returning: .failure(.fetchFailed(error.localizedDescription)))
-                }
-            }
-        }
-    }
-
-    func fetchTopLevelFolders() async -> Result<[Folder], CoreDataError> {
-        await withCheckedContinuation { continuation in
-            container.performBackgroundTask { [weak self] context in
-                guard let self else { return }
-
-                let request = FolderEntity.fetchRequest()
-                request.predicate = NSPredicate(format: "parentFolder == nil AND deletedAt == nil")
-
-                do {
-                    let entities = try context.fetch(request)
-                    for entity in entities {
-                        filterFolderRecursively(entity)
-                    }
-
-                    let topLevelFolders = entities.compactMap(mapper.folder)
-                    print("\(Self.self): ✅ Fetch successfully")
-                    continuation.resume(returning: .success(topLevelFolders))
                 } catch {
                     print("\(Self.self): ❌ Failed to fetch: \(error.localizedDescription)")
                     continuation.resume(returning: .failure(.fetchFailed(error.localizedDescription)))

--- a/Clipster/Clipster/Data/Protocol/Persistence/ClipStorage.swift
+++ b/Clipster/Clipster/Data/Protocol/Persistence/ClipStorage.swift
@@ -1,11 +1,8 @@
 import Foundation
 
 protocol ClipStorage {
-    func fetchClip(by id: UUID) async -> Result<Clip, CoreDataError>
-    func fetchAllClips() async -> Result<[Clip], CoreDataError>
-    func fetchTopLevelClips() async -> Result<[Clip], CoreDataError>
-    func fetchUnvisitedClips() async -> Result<[Clip], CoreDataError>
-    func fetchRecentVisitedClips(for ids: [UUID]) async -> Result<[Clip], CoreDataError>
+    func fetchClip(predicate: NSPredicate) async -> Result<Clip, CoreDataError>
+    func fetchClips(predicate: NSPredicate, fetchLimit: Int) async -> Result<[Clip], CoreDataError>
     func insertClip(_ clip: Clip) async -> Result<Void, CoreDataError>
     func updateClip(_ clip: Clip) async -> Result<Void, CoreDataError>
     func deleteClip(_ clip: Clip) async -> Result<Void, CoreDataError>

--- a/Clipster/Clipster/Data/Protocol/Persistence/FolderStorage.swift
+++ b/Clipster/Clipster/Data/Protocol/Persistence/FolderStorage.swift
@@ -1,9 +1,8 @@
 import CoreData
 
 protocol FolderStorage {
-    func fetchFolder(by id: UUID) async -> Result<Folder, CoreDataError>
-    func fetchAllFolders() async -> Result<[Folder], CoreDataError>
-    func fetchTopLevelFolders() async -> Result<[Folder], CoreDataError>
+    func fetchFolder(predicate: NSPredicate) async -> Result<Folder, CoreDataError>
+    func fetchFolders(predicate: NSPredicate, fetchLimit: Int) async -> Result<[Folder], CoreDataError>
     func insertFolder(_ folder: Folder) async -> Result<Void, CoreDataError>
     func updateFolder(_ folder: Folder) async -> Result<Void, CoreDataError>
     func deleteFolder(_ folder: Folder) async -> Result<Void, CoreDataError>

--- a/Clipster/Clipster/Data/Repository/Clip/DefaultClipRepository.swift
+++ b/Clipster/Clipster/Data/Repository/Clip/DefaultClipRepository.swift
@@ -16,10 +16,10 @@ final class DefaultClipRepository: ClipRepository {
                 return .failure(.entityNotFound)
             }
             return .success(clip)
-        } else {
-            return await storage.fetchClip(by: id)
-                .mapError { _ in .fetchFailed }
         }
+
+        return await storage.fetchClip(by: id)
+            .mapError { _ in .fetchFailed }
     }
 
     func fetchAllClips() async -> Result<[Clip], DomainError> {
@@ -27,10 +27,10 @@ final class DefaultClipRepository: ClipRepository {
            await cache.isClipsInitialized {
             let clips = await cache.clips()
             return .success(clips.filter { $0.deletedAt == nil })
-        } else {
-            return await storage.fetchAllClips()
-                .mapError { _ in .fetchFailed }
         }
+
+        return await storage.fetchAllClips()
+            .mapError { _ in .fetchFailed }
     }
 
     func fetchTopLevelClips() async -> Result<[Clip], DomainError> {
@@ -40,10 +40,10 @@ final class DefaultClipRepository: ClipRepository {
             return .success(clips.filter {
                 $0.folderID == nil && $0.deletedAt == nil
             })
-        } else {
-            return await storage.fetchTopLevelClips()
-                .mapError { _ in .fetchFailed }
         }
+
+        return await storage.fetchTopLevelClips()
+            .mapError { _ in .fetchFailed }
     }
 
     func fetchUnvisitedClips() async -> Result<[Clip], DomainError> {
@@ -53,10 +53,10 @@ final class DefaultClipRepository: ClipRepository {
             return .success(clips.filter {
                 $0.lastVisitedAt == nil && $0.deletedAt == nil
             })
-        } else {
-            return await storage.fetchUnvisitedClips()
-                .mapError { _ in .fetchFailed }
         }
+
+        return await storage.fetchUnvisitedClips()
+            .mapError { _ in .fetchFailed }
     }
 
     func fetchRecentVisitedClips(for ids: [UUID]) async -> Result<[Clip], DomainError> {
@@ -66,10 +66,10 @@ final class DefaultClipRepository: ClipRepository {
             return .success(clips.filter {
                 ids.contains($0.id)
             })
-        } else {
-            return await storage.fetchRecentVisitedClips(for: ids)
-                .mapError { _ in .fetchFailed }
         }
+
+        return await storage.fetchRecentVisitedClips(for: ids)
+            .mapError { _ in .fetchFailed }
     }
 
     func insertClip(_ clip: Clip) async -> Result<Void, DomainError> {

--- a/Clipster/Clipster/Data/Repository/Clip/DefaultClipRepository.swift
+++ b/Clipster/Clipster/Data/Repository/Clip/DefaultClipRepository.swift
@@ -18,7 +18,9 @@ final class DefaultClipRepository: ClipRepository {
             return .success(clip)
         }
 
-        return await storage.fetchClip(by: id)
+        let predicate = NSPredicate(format: "id == %@ AND deletedAt == nil", id as CVarArg)
+
+        return await storage.fetchClip(predicate: predicate)
             .mapError { _ in .fetchFailed }
     }
 
@@ -29,7 +31,9 @@ final class DefaultClipRepository: ClipRepository {
             return .success(clips.filter { $0.deletedAt == nil })
         }
 
-        return await storage.fetchAllClips()
+        let predicate = NSPredicate(format: "deletedAt == nil")
+
+        return await storage.fetchClips(predicate: predicate, fetchLimit: 0)
             .mapError { _ in .fetchFailed }
     }
 
@@ -42,7 +46,9 @@ final class DefaultClipRepository: ClipRepository {
             })
         }
 
-        return await storage.fetchTopLevelClips()
+        let predicate = NSPredicate(format: "folder == nil AND deletedAt == nil")
+
+        return await storage.fetchClips(predicate: predicate, fetchLimit: 0)
             .mapError { _ in .fetchFailed }
     }
 
@@ -55,7 +61,9 @@ final class DefaultClipRepository: ClipRepository {
             })
         }
 
-        return await storage.fetchUnvisitedClips()
+        let predicate = NSPredicate(format: "lastVisitedAt == nil AND deletedAt == nil")
+
+        return await storage.fetchClips(predicate: predicate, fetchLimit: 0)
             .mapError { _ in .fetchFailed }
     }
 
@@ -68,7 +76,9 @@ final class DefaultClipRepository: ClipRepository {
             })
         }
 
-        return await storage.fetchRecentVisitedClips(for: ids)
+        let predicate = NSPredicate(format: "id IN %@ AND deletedAt == nil", ids)
+
+        return await storage.fetchClips(predicate: predicate, fetchLimit: 0)
             .mapError { _ in .fetchFailed }
     }
 

--- a/Clipster/Clipster/Data/Repository/Folder/DefaultFolderRepository.swift
+++ b/Clipster/Clipster/Data/Repository/Folder/DefaultFolderRepository.swift
@@ -16,10 +16,10 @@ final class DefaultFolderRepository: FolderRepository {
                 return .failure(.entityNotFound)
             }
             return .success(folder)
-        } else {
-            return await storage.fetchFolder(by: id)
-                .mapError { _ in .fetchFailed }
         }
+
+        return await storage.fetchFolder(by: id)
+            .mapError { _ in .fetchFailed }
     }
 
     func fetchAllFolders() async -> Result<[Folder], DomainError> {
@@ -27,10 +27,10 @@ final class DefaultFolderRepository: FolderRepository {
            await cache.isFoldersInitialized {
             let folders = await cache.folders()
             return .success(folders.filter { $0.deletedAt == nil })
-        } else {
-            return await storage.fetchAllFolders()
-                .mapError { _ in .fetchFailed }
         }
+
+        return await storage.fetchAllFolders()
+            .mapError { _ in .fetchFailed }
     }
 
     func fetchTopLevelFolders() async -> Result<[Folder], DomainError> {
@@ -38,10 +38,10 @@ final class DefaultFolderRepository: FolderRepository {
            await cache.isFoldersInitialized {
             let folders = await cache.folders()
             return .success(folders.filter { $0.parentFolderID == nil && $0.deletedAt == nil })
-        } else {
-            return await storage.fetchTopLevelFolders()
-                .mapError { _ in .fetchFailed }
         }
+
+        return await storage.fetchTopLevelFolders()
+            .mapError { _ in .fetchFailed }
     }
 
     func insertFolder(_ folder: Folder) async -> Result<Void, DomainError> {

--- a/Clipster/Clipster/Data/Repository/Folder/DefaultFolderRepository.swift
+++ b/Clipster/Clipster/Data/Repository/Folder/DefaultFolderRepository.swift
@@ -18,7 +18,9 @@ final class DefaultFolderRepository: FolderRepository {
             return .success(folder)
         }
 
-        return await storage.fetchFolder(by: id)
+        let predicate = NSPredicate(format: "id == %@ AND deletedAt == nil", id as CVarArg)
+
+        return await storage.fetchFolder(predicate: predicate)
             .mapError { _ in .fetchFailed }
     }
 
@@ -29,7 +31,9 @@ final class DefaultFolderRepository: FolderRepository {
             return .success(folders.filter { $0.deletedAt == nil })
         }
 
-        return await storage.fetchAllFolders()
+        let predicate = NSPredicate(format: "deletedAt == nil")
+
+        return await storage.fetchFolders(predicate: predicate, fetchLimit: 0)
             .mapError { _ in .fetchFailed }
     }
 
@@ -40,7 +44,9 @@ final class DefaultFolderRepository: FolderRepository {
             return .success(folders.filter { $0.parentFolderID == nil && $0.deletedAt == nil })
         }
 
-        return await storage.fetchTopLevelFolders()
+        let predicate = NSPredicate(format: "parentFolder == nil AND deletedAt == nil")
+
+        return await storage.fetchFolders(predicate: predicate, fetchLimit: 0)
             .mapError { _ in .fetchFailed }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

close #710

## 📌 변경 사항 및 이유

Folder, Clip Storage의 fetch에 포함된 비즈니스 로직을 Repository로 이동하여 책임 구분