### PR TITLE
검색 화면 진입 시, 키보드 자동 포커싱 기능 제거

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Search/ViewController/SearchViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Search/ViewController/SearchViewController.swift
@@ -35,11 +35,6 @@ final class SearchViewController: UIViewController, View {
         reactor?.action.onNext(.viewWillAppear)
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        searchView.searchTextField.becomeFirstResponder()
-    }
-
     func bind(reactor: Reactor) {
         bindAction(to: reactor)
         bindState(from: reactor)


### PR DESCRIPTION
## 📌 관련 이슈

close #716 

## 📌 변경 사항 및 이유

검색 화면 진입 시, 키보드 자동 포커싱 기능 제거
