### PR TITLE
Grabber 커스터마이징 제거

### DIFF
--- a/Clipster/Clipster/Presentation/Coordinator/Home/HomeCoordinator.swift
+++ b/Clipster/Clipster/Presentation/Coordinator/Home/HomeCoordinator.swift
@@ -86,6 +86,7 @@ extension HomeCoordinator {
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.custom { $0.maximumDetentValue * 0.75 }]
+            sheet.prefersGrabberVisible = true
         }
         navigationController.present(vc, animated: true)
     }
@@ -101,6 +102,7 @@ extension HomeCoordinator {
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.custom { $0.maximumDetentValue * 0.75 }]
+            sheet.prefersGrabberVisible = true
         }
         navigationController.present(vc, animated: true)
     }

--- a/Clipster/Clipster/Presentation/Coordinator/MyPage/MyPageCoordinator.swift
+++ b/Clipster/Clipster/Presentation/Coordinator/MyPage/MyPageCoordinator.swift
@@ -76,6 +76,7 @@ extension MyPageCoordinator {
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.custom { _ in 290 }]
+            sheet.prefersGrabberVisible = true
         }
 
         navigationController.present(vc, animated: true)
@@ -97,6 +98,7 @@ extension MyPageCoordinator {
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.custom { _ in 290 }]
+            sheet.prefersGrabberVisible = true
         }
 
         navigationController.present(vc, animated: true)

--- a/Clipster/Clipster/Presentation/Coordinator/MyPage/MyPageCoordinator.swift
+++ b/Clipster/Clipster/Presentation/Coordinator/MyPage/MyPageCoordinator.swift
@@ -116,6 +116,7 @@ extension MyPageCoordinator {
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.custom { _ in 290 }]
+            sheet.prefersGrabberVisible = true
         }
 
         navigationController.present(vc, animated: true)

--- a/Clipster/Clipster/Presentation/Coordinator/MyPage/MyPageCoordinator.swift
+++ b/Clipster/Clipster/Presentation/Coordinator/MyPage/MyPageCoordinator.swift
@@ -54,6 +54,7 @@ extension MyPageCoordinator {
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.custom { _ in 290 }]
+            sheet.prefersGrabberVisible = true
         }
 
         navigationController.present(vc, animated: true)

--- a/Clipster/Clipster/Presentation/Scene/EditNickname/SubView/View/EditNicknameView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditNickname/SubView/View/EditNicknameView.swift
@@ -18,13 +18,6 @@ final class EditNicknameView: UIView {
         return view
     }()
 
-    private let grabberView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .textPrimary
-        view.layer.cornerRadius = 2.5
-        return view
-    }()
-
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.textColor = .textPrimary
@@ -107,7 +100,6 @@ private extension EditNicknameView {
 
         [
             baseBackgroundView,
-            grabberView,
             titleLabel,
             saveButton,
             separatorView,
@@ -120,21 +112,14 @@ private extension EditNicknameView {
             make.edges.equalToSuperview()
         }
 
-        grabberView.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(8)
-            make.width.equalTo(134)
-            make.height.equalTo(5)
-            make.centerX.equalToSuperview()
-        }
-
         titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(grabberView.snp.bottom).offset(8)
+            make.top.equalToSuperview().inset(8)
             make.centerX.equalToSuperview()
             make.height.equalTo(48)
         }
 
         saveButton.snp.makeConstraints { make in
-            make.top.equalTo(grabberView.snp.bottom)
+            make.top.equalToSuperview().inset(8)
             make.trailing.equalToSuperview().inset(24)
             make.size.equalTo(48)
         }

--- a/Clipster/Clipster/Presentation/Scene/FolderSelector/Subview/View/FolderSelectorView.swift
+++ b/Clipster/Clipster/Presentation/Scene/FolderSelector/Subview/View/FolderSelectorView.swift
@@ -7,13 +7,6 @@ final class FolderSelectorView: UIView {
 
     private let baseBackgroundView = UIView()
 
-    private let grabberView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .textPrimary
-        view.layer.cornerRadius = 2.5
-        return view
-    }()
-
     let commonNavigationView: CommonNavigationView = {
         let commonNavigationView = CommonNavigationView()
         commonNavigationView.backgroundColor = .cell
@@ -79,7 +72,7 @@ private extension FolderSelectorView {
     }
 
     func setHierarchy() {
-        [baseBackgroundView, grabberView, commonNavigationView, separator, tableView]
+        [baseBackgroundView, commonNavigationView, separator, tableView]
             .forEach { addSubview($0) }
     }
 
@@ -88,15 +81,8 @@ private extension FolderSelectorView {
             make.edges.equalToSuperview()
         }
 
-        grabberView.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(8)
-            make.width.equalTo(134)
-            make.height.equalTo(5)
-            make.centerX.equalToSuperview()
-        }
-
         commonNavigationView.snp.makeConstraints { make in
-            make.top.equalTo(grabberView.snp.bottom).offset(8)
+            make.top.equalToSuperview().inset(8)
             make.directionalHorizontalEdges.equalToSuperview()
         }
 

--- a/Clipster/Clipster/Presentation/Scene/SavePathOptionSelector/SubView/View/SavePathOptionSelectorView.swift
+++ b/Clipster/Clipster/Presentation/Scene/SavePathOptionSelector/SubView/View/SavePathOptionSelectorView.swift
@@ -17,13 +17,6 @@ final class SavePathOptionSelectorView: UIView {
         return view
     }()
 
-    private let grabberView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .textPrimary
-        view.layer.cornerRadius = 2.5
-        return view
-    }()
-
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.textColor = .textPrimary
@@ -88,7 +81,6 @@ private extension SavePathOptionSelectorView {
     func setHierarchy() {
         [
             baseBackgroundView,
-            grabberView,
             titleLabel,
             separatorView,
             accordionRadioView,
@@ -101,15 +93,8 @@ private extension SavePathOptionSelectorView {
             make.edges.equalToSuperview()
         }
 
-        grabberView.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(8)
-            make.width.equalTo(134)
-            make.height.equalTo(5)
-            make.centerX.equalToSuperview()
-        }
-
         titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(grabberView.snp.bottom).offset(8)
+            make.top.equalToSuperview().inset(8)
             make.horizontalEdges.equalToSuperview().inset(24)
             make.height.equalTo(48)
         }

--- a/Clipster/Clipster/Presentation/Scene/SingleOptionSelector/ViewController/SingleOptionSelectorViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/SingleOptionSelector/ViewController/SingleOptionSelectorViewController.swift
@@ -19,13 +19,6 @@ final class SingleOptionSelectorViewController<Option: SelectableOption>: UIView
         return view
     }()
 
-    private let grabberView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .textPrimary
-        view.layer.cornerRadius = 2.5
-        return view
-    }()
-
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.textColor = .textPrimary
@@ -121,7 +114,6 @@ private extension SingleOptionSelectorViewController {
     func setHierarchy() {
         [
             baseBackgroundView,
-            grabberView,
             titleLabel,
             separatorView,
             tableView
@@ -133,15 +125,8 @@ private extension SingleOptionSelectorViewController {
             make.edges.equalToSuperview()
         }
 
-        grabberView.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(8)
-            make.width.equalTo(134)
-            make.height.equalTo(5)
-            make.centerX.equalToSuperview()
-        }
-
         titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(grabberView.snp.bottom).offset(8)
+            make.top.equalToSuperview().inset(8)
             make.horizontalEdges.equalToSuperview().inset(24)
             make.height.equalTo(48)
         }

--- a/Clipster/Clipster/Presentation/Scene/SortOptionSelector/ViewController/SortOptionSelectorViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/SortOptionSelector/ViewController/SortOptionSelectorViewController.swift
@@ -19,13 +19,6 @@ final class SortOptionSelectorViewController<Option: SortableOption>: UIViewCont
         return view
     }()
 
-    private let grabberView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .textPrimary
-        view.layer.cornerRadius = 2.5
-        return view
-    }()
-
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.textColor = .textPrimary
@@ -137,7 +130,6 @@ private extension SortOptionSelectorViewController {
     func setHierarchy() {
         [
             baseBackgroundView,
-            grabberView,
             titleLabel,
             separatorView,
             tableView
@@ -149,15 +141,8 @@ private extension SortOptionSelectorViewController {
             make.edges.equalToSuperview()
         }
 
-        grabberView.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(8)
-            make.width.equalTo(134)
-            make.height.equalTo(5)
-            make.centerX.equalToSuperview()
-        }
-
         titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(grabberView.snp.bottom).offset(8)
+            make.top.equalToSuperview().inset(8)
             make.horizontalEdges.equalToSuperview().inset(24)
             make.height.equalTo(48)
         }

--- a/Clipster/ShareExtension/ViewController/ShareViewController.swift
+++ b/Clipster/ShareExtension/ViewController/ShareViewController.swift
@@ -268,6 +268,7 @@ extension ShareViewController: View {
                 vc.modalPresentationStyle = .pageSheet
                 if let sheet = vc.sheetPresentationController {
                     sheet.detents = [.custom { $0.maximumDetentValue * 0.75 }]
+                    sheet.prefersGrabberVisible = true
                 }
                 self.present(vc, animated: true)
 


### PR DESCRIPTION
## 📌 관련 이슈

close #718 

## 📌 변경 사항 및 이유

- [x] FolderSelectorView, EditNicknameView의 Grabber 제거
- [x] SingleOptionSelectorView, SortOptionSelectorView, SavePathOptionSelectorView의 커스텀 Grabber를 시스템 Grabber로 대체

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 13 mini | <img src="https://github.com/user-attachments/assets/6120fb35-761f-48fe-a8a6-66e317a927e7" width="250px"> |
| iPhone 13 mini | <img src="https://github.com/user-attachments/assets/414fcf95-a55a-4ea2-85a8-8b244284e9b1" width="250px"> |
| iPhone 13 mini | <img src="https://github.com/user-attachments/assets/04c9044c-59ba-4b55-b301-c92221d666af" width="250px"> |
| iPhone 13 mini | <img src="https://github.com/user-attachments/assets/855b9e61-88ce-4916-af7a-f919856b2d77" width="250px"> |

## 📌 PR Point

상단에 자체 헤더(확인 버튼 등)가 있는 경우는 Grabber가 과한 UI라고 생각되어 아예 삭제하였고,
반드시 사용자가 모달을 끌어내려야 하는 경우는 UX에 대한 힌트를 제공해야 한다고 생각하여 시스템 Grabber로 대체하였습니다. (Discord Discussion 참고)