### PR TITLE
온보딩 화면의 skip 버튼을 x 버튼으로 변경

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
@@ -44,9 +44,7 @@ final class OnboardingViewController: UIViewController {
 
     private lazy var skipButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setTitleColor(.appPrimary, for: .normal)
-        button.setTitle("Skip", for: .normal)
-        button.titleLabel?.font = .pretendard(size: 14, weight: .medium)
+        button.setImage(.xGray.withRenderingMode(.alwaysOriginal), for: .normal)
         button.addTarget(self, action: #selector(didTapStart), for: .touchUpInside)
         return button
     }()

--- a/Clipster/Clipster/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
@@ -42,7 +42,7 @@ final class OnboardingViewController: UIViewController {
 
     private var dataSource: UICollectionViewDiffableDataSource<Section, Item>?
 
-    private lazy var skipButton: UIButton = {
+    private lazy var closeButton: UIButton = {
         let button = UIButton(type: .system)
         button.setImage(.xGray.withRenderingMode(.alwaysOriginal), for: .normal)
         button.addTarget(self, action: #selector(didTapStart), for: .touchUpInside)
@@ -142,14 +142,14 @@ private extension OnboardingViewController {
 
     func setHierarchy() {
         [
-            skipButton,
+            closeButton,
             collectionView,
             pageControl
         ].forEach { view.addSubview($0) }
     }
 
     func setConstraints() {
-        skipButton.snp.makeConstraints { make in
+        closeButton.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).inset(14)
             make.trailing.equalToSuperview().inset(24)
         }
@@ -161,7 +161,7 @@ private extension OnboardingViewController {
         }
 
         collectionView.snp.makeConstraints { make in
-            make.top.equalTo(skipButton.snp.bottom).offset(14)
+            make.top.equalTo(closeButton.snp.bottom).offset(14)
             make.horizontalEdges.equalToSuperview()
             make.bottom.equalTo(pageControl.snp.top).offset(-24)
         }


### PR DESCRIPTION
## 📌 관련 이슈

close #722 

## 📌 변경 사항 및 이유

온보딩 화면의 skip 버튼을 x 버튼으로 변경

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 13 mini | <img src="https://github.com/user-attachments/assets/c136dc38-5e47-414d-ac51-08bb539de7a8" width="250px"> |